### PR TITLE
회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	runtimeOnly 'mysql:mysql-connector-java'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/src/main/java/com/example/InstagramCloneCoding/InstagramCloneCodingApplication.java
+++ b/src/main/java/com/example/InstagramCloneCoding/InstagramCloneCodingApplication.java
@@ -1,9 +1,12 @@
 package com.example.InstagramCloneCoding;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class InstagramCloneCodingApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberRegisterApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberRegisterApiController.java
@@ -1,26 +1,42 @@
 package com.example.InstagramCloneCoding.domain.member.api;
 
+import com.example.InstagramCloneCoding.domain.member.application.EmailConfirmService;
 import com.example.InstagramCloneCoding.domain.member.application.MemberRegisterService;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.member.dto.MemberRegisterDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.transaction.Transactional;
 
 
 @RestController
-@RequestMapping("register")
+@Transactional
 public class MemberRegisterApiController {
+
     @Autowired
     private MemberRegisterService memberRegisterService;
+    @Autowired
+    private EmailConfirmService emailConfirmService;
 
-    @PostMapping("")
+    @PostMapping("register")
     public ResponseEntity<Member> register(@RequestBody MemberRegisterDto registerDto) {
-        System.out.println("dabin" + registerDto);
-        return new ResponseEntity(memberRegisterService.register(registerDto), HttpStatus.OK);
+        // 회원가입 (member 테이블에 추가)
+        Member member = memberRegisterService.register(registerDto);
+
+        // 이메일 인증 메일 보내기
+        emailConfirmService.createEmailConfirmationToken(member.getUserId(), member.getEmail());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(member);
+    }
+
+    @GetMapping("confirm-email")
+    public ResponseEntity<Member> confirmEmail(@RequestParam String token) {
+        // 이메일 인증 완료하고 member 테이블의 email_verified 컬럼 true로 바꿔주기
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(emailConfirmService.confirmEmail(token));
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberRegisterApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberRegisterApiController.java
@@ -1,0 +1,26 @@
+package com.example.InstagramCloneCoding.domain.member.api;
+
+import com.example.InstagramCloneCoding.domain.member.application.MemberRegisterService;
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.domain.member.dto.MemberRegisterDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("register")
+public class MemberRegisterApiController {
+    @Autowired
+    private MemberRegisterService memberRegisterService;
+
+    @PostMapping("")
+    public ResponseEntity<Member> register(@RequestBody MemberRegisterDto registerDto) {
+        System.out.println("dabin" + registerDto);
+        return new ResponseEntity(memberRegisterService.register(registerDto), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailConfirmService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailConfirmService.java
@@ -1,0 +1,56 @@
+package com.example.InstagramCloneCoding.domain.member.application;
+
+import com.example.InstagramCloneCoding.domain.member.dao.EmailConfirmationTokenRepository;
+import com.example.InstagramCloneCoding.domain.member.dao.MemberRepository;
+import com.example.InstagramCloneCoding.domain.member.domain.EmailConfirmationToken;
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.global.error.RestApiException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.time.LocalDateTime;
+
+import static com.example.InstagramCloneCoding.domain.member.error.RegisterErrorCode.MEMBER_NOT_FOUND;
+import static com.example.InstagramCloneCoding.domain.member.error.RegisterErrorCode.TOKEN_NOT_FOUND;
+
+@Service
+@Transactional
+public class EmailConfirmService {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private EmailConfirmationTokenRepository emailConfirmationTokenRepository;
+    @Autowired
+    private EmailSenderService emailSenderService;
+
+    public String createEmailConfirmationToken(String userId, String receiverEmail) {
+        EmailConfirmationToken token = EmailConfirmationToken.createEmailConfirmationToken(userId);
+        emailConfirmationTokenRepository.save(token);
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(receiverEmail);
+        message.setSubject("인스타그램(클론) 회원가입 이메일 인증");
+        message.setText("http://localhost:8080/confirm-email?token=" + token.getId());
+        emailSenderService.sendEmail(message);
+
+        return token.getId();
+    }
+
+    public Member confirmEmail(String token) {
+        EmailConfirmationToken findToken = emailConfirmationTokenRepository
+                .findByIdAndExpirationDateAfterAndExpired(token, LocalDateTime.now(), false)
+                .orElseThrow(() -> new RestApiException(TOKEN_NOT_FOUND));
+        Member member = memberRepository.findById(findToken.getUserId())
+                .orElseThrow(() -> new RestApiException(MEMBER_NOT_FOUND));
+
+        findToken.useToken();
+        member.setEmailVerified(true);
+        emailConfirmationTokenRepository.save(findToken);
+        memberRepository.save(member);
+
+        return member;
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailSenderService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailSenderService.java
@@ -1,0 +1,19 @@
+package com.example.InstagramCloneCoding.domain.member.application;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailSenderService {
+
+    @Autowired
+    private JavaMailSender javaMailSender;
+
+    @Async
+    public void sendEmail(SimpleMailMessage email) {
+        javaMailSender.send(email);
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberRegisterService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberRegisterService.java
@@ -1,0 +1,48 @@
+package com.example.InstagramCloneCoding.domain.member.application;
+
+import com.example.InstagramCloneCoding.domain.member.dao.MemberRepository;
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.domain.member.dto.MemberRegisterDto;
+import com.example.InstagramCloneCoding.domain.member.error.RegisterErrorCode;
+import com.example.InstagramCloneCoding.global.error.RestApiException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+public class MemberRegisterService {
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public Member register(MemberRegisterDto registerDto) {
+        // 아이디 중복 확인
+        Member member = memberRepository.findById(registerDto.getUserId()).orElse(null);
+        if (member != null) {
+            throw new RestApiException(RegisterErrorCode.ID_ALREADY_EXISTS);
+        }
+
+        // 이메일 중복 확인
+        member = memberRepository.findByEmail(registerDto.getEmail()).orElse(null);
+        if (member != null) {
+            throw new RestApiException(RegisterErrorCode.EMAIL_ALREADY_REGISTERED);
+        }
+
+        // 비밀번호 확인
+        if (!registerDto.getPassword().equals(registerDto.getConfirmPassword())) {
+            throw new RestApiException(RegisterErrorCode.WRONG_CONFIRM_PASSWORD);
+        }
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(registerDto.getPassword());
+
+        // 저장
+        member = new Member(registerDto.getEmail(), registerDto.getUserId(), encodedPassword);
+        return memberRepository.save(member);
+    }
+}
+

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberRegisterService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberRegisterService.java
@@ -1,6 +1,7 @@
 package com.example.InstagramCloneCoding.domain.member.application;
 
 import com.example.InstagramCloneCoding.domain.member.dao.MemberRepository;
+import com.example.InstagramCloneCoding.domain.member.domain.EmailConfirmationToken;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.member.dto.MemberRegisterDto;
 import com.example.InstagramCloneCoding.domain.member.error.RegisterErrorCode;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 import javax.transaction.Transactional;
 
 @Service
+@Transactional
 public class MemberRegisterService {
 
     @Autowired
@@ -19,7 +21,6 @@ public class MemberRegisterService {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
-    @Transactional
     public Member register(MemberRegisterDto registerDto) {
         // 아이디 중복 확인
         Member member = memberRepository.findById(registerDto.getUserId()).orElse(null);

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberRegisterService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberRegisterService.java
@@ -13,6 +13,7 @@ import javax.transaction.Transactional;
 
 @Service
 public class MemberRegisterService {
+
     @Autowired
     private MemberRepository memberRepository;
     @Autowired

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/dao/EmailConfirmationTokenRepository.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/dao/EmailConfirmationTokenRepository.java
@@ -1,0 +1,13 @@
+package com.example.InstagramCloneCoding.domain.member.dao;
+
+import com.example.InstagramCloneCoding.domain.member.domain.EmailConfirmationToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface EmailConfirmationTokenRepository extends JpaRepository<EmailConfirmationToken, String> {
+
+    Optional<EmailConfirmationToken> findByIdAndExpirationDateAfterAndExpired(
+            String emailConfirmationTokenId, LocalDateTime now, boolean expired);
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/dao/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.example.InstagramCloneCoding.domain.member.dao;
+
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, String> {
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/dao/MemberRepository.java
@@ -8,5 +8,6 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, String> {
+
     Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/EmailConfirmationToken.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/EmailConfirmationToken.java
@@ -1,0 +1,57 @@
+package com.example.InstagramCloneCoding.domain.member.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.GenericGenerator;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "email_confirmation_token")
+@Getter @Setter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class EmailConfirmationToken {
+
+    private static final long EMAIL_TOKEN_EXPIRATION_TIME_VALUE = 5L; // 토큰 만료 시간
+
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(name = "id", nullable = false)
+    private String id;
+
+    @Column(name = "expiration_date", nullable = false)
+    private LocalDateTime expirationDate;
+
+    @Column(name = "expired", nullable = false)
+    private boolean expired;
+
+    @Column(name = "user_id", nullable = false)
+    private String userId; // FK 아님
+
+    @CreatedDate
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
+
+/*    @LastModifiedDate
+    @Column
+    private LocalDateTime lastModifiedDate;*/
+
+    public static EmailConfirmationToken createEmailConfirmationToken(String userId) {
+        EmailConfirmationToken token = new EmailConfirmationToken();
+        token.setExpirationDate(LocalDateTime.now().plusMinutes(EMAIL_TOKEN_EXPIRATION_TIME_VALUE));
+        token.setUserId(userId);
+        token.setExpired(false);
+
+        return token;
+    }
+
+    public void useToken() {
+        expired = true;
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
@@ -14,6 +14,7 @@ import javax.persistence.Table;
 @Getter @Setter
 @NoArgsConstructor
 public class Member {
+
     @Id
     @Column(name = "user_id")
     String userId;

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
@@ -1,0 +1,41 @@
+package com.example.InstagramCloneCoding.domain.member.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "member")
+@Getter @Setter
+@NoArgsConstructor
+public class Member {
+    @Id
+    @Column(name = "user_id")
+    String userId;
+
+    @Column(name = "email", nullable = false)
+    String email;
+
+    @Column(name = "password", nullable = false)
+    String password;
+
+    @Column(name = "profile_image")
+    String profileImage;
+
+    @Column(name = "name", nullable = false)
+    String name;
+
+    @Column(name = "introduction")
+    String introduction;
+
+    public Member(String email, String userId, String password) {
+        this.email = email;
+        this.userId = userId;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
@@ -34,9 +34,13 @@ public class Member {
     @Column(name = "introduction")
     String introduction;
 
+    @Column(name = "email_verified", nullable = false)
+    boolean emailVerified;
+
     public Member(String email, String userId, String password) {
         this.email = email;
         this.userId = userId;
         this.password = password;
+        this.emailVerified = false;
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/dto/MemberRegisterDto.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/dto/MemberRegisterDto.java
@@ -6,9 +6,8 @@ import lombok.Setter;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 
-@Getter
-@Setter
-public class UserRegisterRequestDto {
+@Getter @Setter
+public class MemberRegisterDto {
 
     @NotBlank
     private String userId;

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/error/RegisterErrorCode.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/error/RegisterErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.InstagramCloneCoding.domain.member.error;
+
+import com.example.InstagramCloneCoding.global.error.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@AllArgsConstructor
+public enum RegisterErrorCode implements ErrorCode {
+
+    ID_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "ID already exists"),
+    EMAIL_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "Email is already registered"),
+    WRONG_CONFIRM_PASSWORD(HttpStatus.BAD_REQUEST, "confirm password is wrong"),
+    ;
+
+    private HttpStatus httpStatus;
+    private String message;
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/error/RegisterErrorCode.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/error/RegisterErrorCode.java
@@ -13,6 +13,8 @@ public enum RegisterErrorCode implements ErrorCode {
     ID_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "ID already exists"),
     EMAIL_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "Email is already registered"),
     WRONG_CONFIRM_PASSWORD(HttpStatus.BAD_REQUEST, "confirm password is wrong"),
+    TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "token not found"),
+    MEMBER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "member not found"),
     ;
 
     private HttpStatus httpStatus;

--- a/src/main/java/com/example/InstagramCloneCoding/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.cors().disable()        // cors 방지

--- a/src/main/java/com/example/InstagramCloneCoding/global/error/CommonErrorCode.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/error/CommonErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum CommonErrorCode implements ErrorCode {
 
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included"),
-    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resouce not exists"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not exists"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
     ;
 

--- a/src/main/java/com/example/InstagramCloneCoding/global/error/CommonErrorCode.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/error/CommonErrorCode.java
@@ -1,0 +1,18 @@
+package com.example.InstagramCloneCoding.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resouce not exists"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
+    ;
+
+    private HttpStatus httpStatus;
+    private String message;
+}

--- a/src/main/java/com/example/InstagramCloneCoding/global/error/ErrorCode.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/error/ErrorCode.java
@@ -1,0 +1,10 @@
+package com.example.InstagramCloneCoding.global.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    String name();
+    HttpStatus getHttpStatus();
+    String getMessage();
+}

--- a/src/main/java/com/example/InstagramCloneCoding/global/error/ErrorResponseDto.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/error/ErrorResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.InstagramCloneCoding.global.error;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ErrorResponseDto {
+
+    private String code;
+    private String message;
+}

--- a/src/main/java/com/example/InstagramCloneCoding/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,34 @@
+package com.example.InstagramCloneCoding.global.error;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(RestApiException.class)
+    public ResponseEntity<Object> handleRestApiException(RestApiException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return handleExceptionInternal(errorCode);
+    }
+
+    @ExceptionHandler({Exception.class})
+    public ResponseEntity<Object> handleAllException(Exception e) {
+        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        return handleExceptionInternal(errorCode);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponse(errorCode));
+    }
+
+    private ErrorResponseDto makeErrorResponse(ErrorCode errorCode) {
+        return ErrorResponseDto.builder()
+                .code(errorCode.name())
+                .message(errorCode.getMessage())
+                .build();
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/error/GlobalExceptionHandler.java
@@ -14,11 +14,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return handleExceptionInternal(errorCode);
     }
 
-    @ExceptionHandler({Exception.class})
-    public ResponseEntity<Object> handleAllException(Exception e) {
-        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
-        return handleExceptionInternal(errorCode);
-    }
+    // 패키지 구조 같은 거 숨기는 목적. 근데 개발 단계에서는 오류잡을 때 불편하므로 주석처리 해 놓았음
+//    @ExceptionHandler({Exception.class})
+//    public ResponseEntity<Object> handleAllException(Exception e) {
+//        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+//        return handleExceptionInternal(errorCode);
+//    }
 
     private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
         return ResponseEntity.status(errorCode.getHttpStatus())

--- a/src/main/java/com/example/InstagramCloneCoding/global/error/RestApiException.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/error/RestApiException.java
@@ -1,0 +1,11 @@
+package com.example.InstagramCloneCoding.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RestApiException extends RuntimeException {
+
+    private ErrorCode errorCode;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,19 @@ spring:
     username: ${RDS_USERNAME}
     url: ${RDS_URL}
     password: ${RDS_PASSWORD}
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GOOGLE_USERNAME_FOR_SMTP}
+    password: ${GOOGLE_PASSWORD_FOR_SMTP}
+    properties:
+      mail:
+        smtp:
+          starttls:
+            enable: true
+            required: true
+          auth: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000


### PR DESCRIPTION
## 개요
- 회원가입 기능 구현
- 이메일 인증 구현
- 예외 처리 구현

## 작업사항
- 회원가입 기능, 이메일 인증 구현
  - /register로 이메일과 아이디, 비밀번호, 확인용 비밀번호를 보내면 아이디와 이메일 중복 확인을 한 후 비밀번호와 확인용 비밀번호가 일치하는지 확인한다. 그러고나서 member 테이블에 저장되는데, 이때 email_verified 컬럼은 false로 저장된다.
  - member 테이블에 회원정보를 저장한 다음 이메일로 인증 메일을 보낸다. 인증 메일 안에 있는 링크(/email-confirm)를 클릭하면 인증이 완료된다. 토큰을 만들어 구현하였는데, 이를 위해 email_confirmation_token 테이블을추가하였다. 이메일 인증이 완료되었으므로 member 테이블의 email_verified 컬럼이 true로 바뀐다.
  - member 테이블에 email_verified 컬럼을 추가하였으므로 로그인 시 email_verified 값이 true인지 확인하는 절차가 필요하다.
  - 참고한 게시물: https://programmer93.tistory.com/69
- 예외 처리 구현
  - @ExceptionHandler와 @RestControllerAdvice 어노테이션을 사용하여 예외 처리를 구현하였다.
  - 사용방법: 우선 ErrorCode를 구현하는 enum 클래스를 만든 뒤, httpStatus와 message 값을 갖는 상수값을 정의한다. 그런 다음 예외 처리할 때 RestApiException 클래스를 던지면 되는데, 이때 생성자에 앞서 구현한 ErrorCode 값을 넣으면 된다. (RegisterErrorCode.java와 MemberRegisterService.java 참고!!)
  - 참고한 게시물: https://mangkyu.tistory.com/204 https://mangkyu.tistory.com/205
