### PR TITLE
Argument Resolver 등록

### DIFF
--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
@@ -44,7 +44,7 @@ public class MemberService {
         String encodedPassword = passwordEncoder.encode(registerDto.getPassword());
 
         // 저장
-        member = new Member(registerDto.getEmail(), registerDto.getUserId(), encodedPassword);
+        member = new Member(registerDto.getEmail(), registerDto.getUserId(),registerDto.getName(), encodedPassword);
         return memberRepository.save(member);
     }
 

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
@@ -37,9 +37,10 @@ public class Member {
     @Column(name = "email_verified", nullable = false)
     boolean emailVerified;
 
-    public Member(String email, String userId, String password) {
+    public Member(String email, String userId, String name, String password) {
         this.email = email;
         this.userId = userId;
+        this.name = name;
         this.password = password;
         this.emailVerified = false;
     }

--- a/src/main/java/com/example/InstagramCloneCoding/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/auth/jwt/JwtTokenProvider.java
@@ -4,6 +4,7 @@ import com.example.InstagramCloneCoding.global.auth.dto.TokenDto;
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -33,6 +34,9 @@ public class JwtTokenProvider {
     private long refreshTokenValidateTime;
     public static final String BEARER_PREFIX = "Bearer ";
     private static final String AUTHORITIES_KEY = "auth";
+
+    @Autowired
+    private final JwtUserDetailsService jwtUserDetailsService;
 
     @PostConstruct
     protected void init() {
@@ -78,7 +82,9 @@ public class JwtTokenProvider {
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
 
-        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        //UserDetails principal = new User(claims.getSubject(), "", authorities);
+        UserDetails principal = jwtUserDetailsService.loadUserByUsername(claims.getSubject());
+
         return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }
 

--- a/src/main/java/com/example/InstagramCloneCoding/global/auth/jwt/JwtUserDetails.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/auth/jwt/JwtUserDetails.java
@@ -1,6 +1,7 @@
 package com.example.InstagramCloneCoding.global.auth.jwt;
 
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -9,6 +10,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+
+@Getter
 public class JwtUserDetails implements UserDetails {
     private final Member member;
     private final List<GrantedAuthority> authorities = new ArrayList<>();

--- a/src/main/java/com/example/InstagramCloneCoding/global/common/annotation/LoggedInUser.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/common/annotation/LoggedInUser.java
@@ -1,0 +1,11 @@
+package com.example.InstagramCloneCoding.global.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoggedInUser {
+}

--- a/src/main/java/com/example/InstagramCloneCoding/global/common/resolver/LoggedInUserArgumentResolver.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/common/resolver/LoggedInUserArgumentResolver.java
@@ -1,0 +1,43 @@
+package com.example.InstagramCloneCoding.global.common.resolver;
+
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.global.auth.jwt.JwtUserDetails;
+import com.example.InstagramCloneCoding.global.common.annotation.LoggedInUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoggedInUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        // 호출되는 컨트롤러 파라미터의 어노테이션과 타입 검사
+        return parameter.getParameterAnnotation(LoggedInUser.class) != null
+                && parameter.getParameterType().equals(Member.class);
+    }
+
+    // supportsParameter 콜백 함수에서 true를 반환했을 경우 실행
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) throws Exception {
+        JwtUserDetails userDetails = null;
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null) {
+            userDetails = (JwtUserDetails) authentication.getPrincipal();
+            return userDetails.getMember();
+        }
+        else
+            return null;
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/config/SecurityConfig.java
@@ -39,7 +39,8 @@ public class SecurityConfig {
                 .authorizeRequests()
                 .antMatchers("/signin").permitAll() // 모든 요청 허가
                 .antMatchers("/reissue").permitAll()
-                .antMatchers("/accounts/**").permitAll()
+                .antMatchers("/accounts/emailsignup").permitAll()
+                .antMatchers("/accounts/confirm-email").permitAll()
                 .antMatchers(SWAGGER_LIST).permitAll()
                 .anyRequest().authenticated()   // 나머지 인증 필요
                 .and()

--- a/src/main/java/com/example/InstagramCloneCoding/global/config/WebMvcConfig.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/config/WebMvcConfig.java
@@ -1,11 +1,25 @@
 package com.example.InstagramCloneCoding.global.config;
 
+import com.example.InstagramCloneCoding.global.common.resolver.LoggedInUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
 @EnableWebMvc
+@RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
 
+    @Autowired
+    private final LoggedInUserArgumentResolver loggedInUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loggedInUserArgumentResolver);
+    }
 }


### PR DESCRIPTION
## 개요
security context에서 매번 authentication 가져오지 않아도 되도록 argument resolver를 이용하여 파라미터 처리를 해줌

## 작업사항
- WebMvcConfigurer를 구현한 WebMvcConfig 클래스에서 addArgumentResolvers 메소드를 오버라이드하여 LoggedInUserArgumentResolver를 등록함.
- 컨트롤러에서 파라미터에 @LoggedInUser 어노테이션이 붙어있고 타입이 Member 클래스이면 security context에 저장된 유저 정보가 들어감. LoggedInUserArgumentResolver의 supportsParameter 메소드가 파라미터의 어노테이션과 타입을 검사하고 resolveArgument 메소드가 security context에서 유저정보를 찾아 반환함.

## 변경로직
- JwtTokenProvider의 getAuthentication 메소드 일부 수정 (변경 전 코드는 주석처리 해놓았음)
  UserDetails principal = new User(claims.getSubject(), "", authorities);
  -->
  UserDetails principal = jwtUserDetailsService.loadUserByUsername(claims.getSubject());
