### PR TITLE
Follow 기능 구현

### DIFF
--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/api/FollowApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/api/FollowApiController.java
@@ -14,13 +14,13 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/follow")
+@RequestMapping("/relationship")
 public class FollowApiController {
 
     private final FollowService followService;
     private final MemberService memberService;
 
-    @PostMapping("/searchmember")
+    @GetMapping("/searchmember")
     public ResponseEntity<String> searchMember(@RequestParam String userId) {
         memberService.existMember(userId);
 
@@ -28,8 +28,8 @@ public class FollowApiController {
                 .body("member exist");
     }
 
-    @PostMapping("/following")
-    public ResponseEntity<String> following(@LoggedInUser Member member, @RequestBody FollowDto followDto) {
+    @PostMapping("/follow")
+    public ResponseEntity<String> follow(@LoggedInUser Member member, @RequestBody FollowDto followDto) {
         memberService.existMember(followDto.getFollowingOrFollowerId());
         followService.follow(member.getUserId(), followDto.getFollowingOrFollowerId());
 
@@ -37,7 +37,7 @@ public class FollowApiController {
                 .body("following success!");
     }
 
-    @PostMapping("/unfollow")
+    @DeleteMapping("/unfollow")
     public ResponseEntity<String> unfollow(@LoggedInUser Member member, @RequestBody FollowDto followDto) {
         followService.unfollow(member.getUserId(), followDto.getFollowingOrFollowerId());
 
@@ -45,7 +45,7 @@ public class FollowApiController {
                 .body("unfollow success!");
     }
 
-    @GetMapping("/followers")
+    @GetMapping("/getfollowers")
     public ResponseEntity<List<String>> followers(@LoggedInUser Member member) {
         List<String> followers = followService.getFollowers(member.getUserId());
 
@@ -53,7 +53,7 @@ public class FollowApiController {
                 .body(followers);
     }
 
-    @GetMapping("/followings")
+    @GetMapping("/getfollowings")
     public ResponseEntity<List<String>> followings(@LoggedInUser Member member) {
         List<String> followings = followService.getFollowings(member.getUserId());
 
@@ -61,7 +61,7 @@ public class FollowApiController {
                 .body(followings);
     }
 
-    @GetMapping("/followback")
+    @GetMapping("/getfollowbacks")
     public ResponseEntity<List<String>> followBack(@LoggedInUser Member member) {
         List<String> friends = followService.getFollowBacks(member.getUserId());
 

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/api/FollowApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/api/FollowApiController.java
@@ -1,0 +1,71 @@
+package com.example.InstagramCloneCoding.domain.follow.api;
+
+import com.example.InstagramCloneCoding.domain.follow.application.FollowService;
+import com.example.InstagramCloneCoding.domain.follow.dto.FollowDto;
+import com.example.InstagramCloneCoding.domain.member.application.MemberService;
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.global.common.annotation.LoggedInUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/follow")
+public class FollowApiController {
+
+    private final FollowService followService;
+    private final MemberService memberService;
+
+    @PostMapping("/searchmember")
+    public ResponseEntity<String> searchMember(@RequestParam String userId) {
+        memberService.existMember(userId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body("member exist");
+    }
+
+    @PostMapping("/following")
+    public ResponseEntity<String> following(@LoggedInUser Member member, @RequestBody FollowDto followDto) {
+        memberService.existMember(followDto.getFollowingOrFollowerId());
+        followService.follow(member.getUserId(), followDto.getFollowingOrFollowerId());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body("following success!");
+    }
+
+    @PostMapping("/unfollow")
+    public ResponseEntity<String> unfollow(@LoggedInUser Member member, @RequestBody FollowDto followDto) {
+        followService.unfollow(member.getUserId(), followDto.getFollowingOrFollowerId());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body("unfollow success!");
+    }
+
+    @GetMapping("/followers")
+    public ResponseEntity<List<String>> followers(@LoggedInUser Member member) {
+        List<String> followers = followService.getFollowers(member.getUserId());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(followers);
+    }
+
+    @GetMapping("/followings")
+    public ResponseEntity<List<String>> followings(@LoggedInUser Member member) {
+        List<String> followings = followService.getFollowings(member.getUserId());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(followings);
+    }
+
+    @GetMapping("/followback")
+    public ResponseEntity<List<String>> followBack(@LoggedInUser Member member) {
+        List<String> friends = followService.getFollowBacks(member.getUserId());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(friends);
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/api/FollowApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/api/FollowApiController.java
@@ -5,6 +5,7 @@ import com.example.InstagramCloneCoding.domain.follow.dto.FollowDto;
 import com.example.InstagramCloneCoding.domain.member.application.MemberService;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.global.common.annotation.LoggedInUser;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -29,7 +30,7 @@ public class FollowApiController {
     }
 
     @PostMapping("/follow")
-    public ResponseEntity<String> follow(@LoggedInUser Member member, @RequestBody FollowDto followDto) {
+    public ResponseEntity<String> follow(@Parameter(hidden = true) @LoggedInUser Member member, @RequestBody FollowDto followDto) {
         memberService.existMember(followDto.getFollowingOrFollowerId());
         followService.follow(member.getUserId(), followDto.getFollowingOrFollowerId());
 
@@ -38,7 +39,7 @@ public class FollowApiController {
     }
 
     @DeleteMapping("/unfollow")
-    public ResponseEntity<String> unfollow(@LoggedInUser Member member, @RequestBody FollowDto followDto) {
+    public ResponseEntity<String> unfollow(@Parameter(hidden = true) @LoggedInUser Member member, @RequestBody FollowDto followDto) {
         followService.unfollow(member.getUserId(), followDto.getFollowingOrFollowerId());
 
         return ResponseEntity.status(HttpStatus.OK)
@@ -46,7 +47,7 @@ public class FollowApiController {
     }
 
     @GetMapping("/getfollowers")
-    public ResponseEntity<List<String>> followers(@LoggedInUser Member member) {
+    public ResponseEntity<List<String>> followers(@Parameter(hidden = true) @LoggedInUser Member member) {
         List<String> followers = followService.getFollowers(member.getUserId());
 
         return ResponseEntity.status(HttpStatus.OK)
@@ -54,7 +55,7 @@ public class FollowApiController {
     }
 
     @GetMapping("/getfollowings")
-    public ResponseEntity<List<String>> followings(@LoggedInUser Member member) {
+    public ResponseEntity<List<String>> followings(@Parameter(hidden = true) @LoggedInUser Member member) {
         List<String> followings = followService.getFollowings(member.getUserId());
 
         return ResponseEntity.status(HttpStatus.OK)
@@ -62,7 +63,7 @@ public class FollowApiController {
     }
 
     @GetMapping("/getfollowbacks")
-    public ResponseEntity<List<String>> followBack(@LoggedInUser Member member) {
+    public ResponseEntity<List<String>> followBack(@Parameter(hidden = true) @LoggedInUser Member member) {
         List<String> friends = followService.getFollowBacks(member.getUserId());
 
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowService.java
@@ -1,0 +1,64 @@
+package com.example.InstagramCloneCoding.domain.follow.application;
+
+import com.example.InstagramCloneCoding.domain.follow.dao.FollowRepository;
+import com.example.InstagramCloneCoding.domain.follow.domain.Follow;
+import com.example.InstagramCloneCoding.domain.follow.domain.FollowId;
+import com.example.InstagramCloneCoding.global.error.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.InstagramCloneCoding.domain.follow.error.FollowError.ALREADY_FOLLOWING;
+import static com.example.InstagramCloneCoding.domain.follow.error.FollowError.NOT_FOLLOWING;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FollowService {
+
+    private final FollowRepository followRepository;
+
+    public void follow(String memberID, String followingId) {
+        FollowId followId = new FollowId(memberID, followingId);
+        // follow 중복 검사
+        followRepository.findById(followId)
+                .ifPresent(x -> {
+                    throw new RestApiException(ALREADY_FOLLOWING);
+                });
+
+        followRepository.save(new Follow(memberID, followingId));
+    }
+
+    public void unfollow(String memeberId, String followingId) {
+        FollowId followId = new FollowId(memeberId, followingId);
+        // follow 확인
+        if (followRepository.findById(followId).isEmpty()) {
+            throw new RestApiException(NOT_FOLLOWING);
+        }
+
+        followRepository.delete(new Follow(memeberId, followingId));
+    }
+
+    public List<String> getFollowers(String memberId) {
+        List<Follow> followerList = followRepository.findByFollowingId(memberId);
+        return followerList.stream()
+                .map(Follow::getFollowerId)
+                .collect(Collectors.toList());
+    }
+
+    public List<String> getFollowings(String memberId) {
+        List<Follow> followingList = followRepository.findByFollowerId(memberId);
+        return followingList.stream()
+                .map(Follow::getFollowingId)
+                .collect(Collectors.toList());
+    }
+
+    public List<String> getFollowBacks(String memberId) {
+        List<String> followBackList = getFollowings(memberId);
+        followBackList.retainAll(getFollowers(memberId));
+        return followBackList;
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/dao/FollowRepository.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/dao/FollowRepository.java
@@ -1,0 +1,14 @@
+package com.example.InstagramCloneCoding.domain.follow.dao;
+
+import com.example.InstagramCloneCoding.domain.follow.domain.Follow;
+import com.example.InstagramCloneCoding.domain.follow.domain.FollowId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FollowRepository extends JpaRepository<Follow, FollowId> {
+
+    List<Follow> findByFollowerId(String followId);
+
+    List<Follow> findByFollowingId(String followingId);
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/domain/Follow.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/domain/Follow.java
@@ -1,0 +1,26 @@
+package com.example.InstagramCloneCoding.domain.follow.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "follow")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@IdClass(FollowId.class)
+public class Follow {
+
+    @Id
+    @Column(name = "follower_id", nullable = false)
+    String followerId;
+
+    @Id
+    @Column(name = "following_id", nullable = false)
+    String followingId;
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/domain/FollowId.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/domain/FollowId.java
@@ -1,0 +1,20 @@
+package com.example.InstagramCloneCoding.domain.follow.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import java.io.Serializable;
+
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowId implements Serializable {
+
+    @Column(name = "follower_id", nullable = false)
+    String followerId;
+
+    @Column(name = "following_id", nullable = false)
+    String followingId;
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/dto/FollowDto.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/dto/FollowDto.java
@@ -1,0 +1,14 @@
+package com.example.InstagramCloneCoding.domain.follow.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Setter
+public class FollowDto {
+
+    @NotBlank
+    String followingOrFollowerId;
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/error/FollowError.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/error/FollowError.java
@@ -1,0 +1,17 @@
+package com.example.InstagramCloneCoding.domain.follow.error;
+
+import com.example.InstagramCloneCoding.global.error.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum FollowError implements ErrorCode {
+
+    ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST, "Already following."),
+    NOT_FOLLOWING(HttpStatus.BAD_REQUEST, "Not following.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
@@ -44,18 +44,24 @@ public class MemberService {
         String encodedPassword = passwordEncoder.encode(registerDto.getPassword());
 
         // 저장
-        member = new Member(registerDto.getEmail(), registerDto.getUserId(),registerDto.getName(), encodedPassword);
+        member = new Member(registerDto.getEmail(), registerDto.getUserId(), registerDto.getName(), encodedPassword);
         return memberRepository.save(member);
     }
 
-    public Member changeProfileImage(String userId, String imagePath) {
+    public void changeProfileImage(String userId, String imagePath) {
         // 멤버 가져오기
         Member member = memberRepository.findById(userId)
                 .orElseThrow(() -> new RestApiException(MEMBER_NOT_FOUND));
 
         // 프로필 이미지 경로 업데이트
         member.setProfileImage(imagePath);
-        return memberRepository.save(member);
+        memberRepository.save(member);
+    }
+
+    public void existMember(String userId) {
+        if (memberRepository.findById(userId).isEmpty()) {
+            throw new RestApiException(MEMBER_NOT_FOUND);
+        }
     }
 }
 

--- a/src/main/java/com/example/InstagramCloneCoding/global/auth/api/JwtAuthenticationController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/auth/api/JwtAuthenticationController.java
@@ -4,6 +4,7 @@ import com.example.InstagramCloneCoding.global.auth.dto.LoginRequestDto;
 import com.example.InstagramCloneCoding.global.auth.dto.TokenDto;
 import com.example.InstagramCloneCoding.global.auth.service.AuthService;
 import com.example.InstagramCloneCoding.global.auth.service.HeaderService;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +26,7 @@ public class JwtAuthenticationController {
     }
 
     @PostMapping("reissue")
-    public ResponseEntity<TokenDto> reissue(@RequestHeader("Authorization") String authorization,
+    public ResponseEntity<TokenDto> reissue(@Parameter(hidden = true) @RequestHeader("Authorization") String authorization,
                                             @RequestHeader("RefreshToken") String refreshToken) {
         TokenDto tokenDto = authService.reissue(headerService.getAccessToken(authorization), refreshToken);
         return ResponseEntity.status(HttpStatus.OK)
@@ -33,7 +34,7 @@ public class JwtAuthenticationController {
     }
 
     @PostMapping("signout")
-    public ResponseEntity<String> signOut(@RequestHeader("Authorization") String authorization) {
+    public ResponseEntity<String> signOut(@Parameter(hidden = true) @RequestHeader("Authorization") String authorization) {
         authService.signOut(headerService.getAccessToken(authorization));
         return ResponseEntity.status(HttpStatus.OK)
                 .body("signout success");

--- a/src/main/java/com/example/InstagramCloneCoding/global/auth/api/JwtAuthenticationController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/auth/api/JwtAuthenticationController.java
@@ -7,13 +7,11 @@ import com.example.InstagramCloneCoding.global.auth.service.HeaderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/auth")
 public class JwtAuthenticationController {
 
     private final AuthService authService;
@@ -39,10 +37,5 @@ public class JwtAuthenticationController {
         authService.signOut(headerService.getAccessToken(authorization));
         return ResponseEntity.status(HttpStatus.OK)
                 .body("signout success");
-    }
-
-    @PostMapping("test")
-    public String test() {
-        return "login success";
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/global/auth/error/AuthErrorCode.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/auth/error/AuthErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "Invalid JWT token"),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "Invalid ACCESS token"),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Invalid Refresh token"),
     WRONG_ID_PASSWORD(HttpStatus.BAD_REQUEST, "wrong id or password");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/InstagramCloneCoding/global/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -12,14 +12,14 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-import static com.example.InstagramCloneCoding.global.auth.error.AuthErrorCode.INVALID_TOKEN;
+import static com.example.InstagramCloneCoding.global.auth.error.AuthErrorCode.INVALID_ACCESS_TOKEN;
 
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         // 유효한 자격증명을 제공하지 않고 접근 -> 401에러
-        ErrorCode errorCode = INVALID_TOKEN;
+        ErrorCode errorCode = INVALID_ACCESS_TOKEN;
 
         response.setStatus(errorCode.getHttpStatus().value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/com/example/InstagramCloneCoding/global/auth/service/AuthService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/auth/service/AuthService.java
@@ -14,6 +14,7 @@ import javax.transaction.Transactional;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
+import static com.example.InstagramCloneCoding.global.auth.error.AuthErrorCode.INVALID_REFRESH_TOKEN;
 import static com.example.InstagramCloneCoding.global.auth.error.AuthErrorCode.WRONG_ID_PASSWORD;
 
 @Service
@@ -46,8 +47,9 @@ public class AuthService {
 
     public TokenDto reissue(String accessToken, String refreshToken) {
         Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+        // refresh token 유효기간 확인
         if (!refreshToken.equals(redisTemplate.opsForValue().get("RT:" + authentication.getName()))) {
-            return null;
+            throw new RestApiException(INVALID_REFRESH_TOKEN);
         }
 
         TokenDto tokenDto = jwtTokenProvider.generateToken(authentication);

--- a/src/main/java/com/example/InstagramCloneCoding/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/config/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisTemplate<String, String> redisTemplate;
-    private static final String[] SWAGGER_LIST={
+    private static final String[] SWAGGER_LIST = {
             // swagger 접근 허용
             "/v3/api-docs/**",
             "/swagger-ui/**",
@@ -37,8 +37,8 @@ public class SecurityConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션 사용x(jwt 사용)
                 .and()
                 .authorizeRequests()
-                .antMatchers("auth/signin").permitAll() // 모든 요청 허가
-                .antMatchers("auth/reissue").permitAll()
+                .antMatchers("/auth/signin").permitAll() // 모든 요청 허가
+                .antMatchers("/auth/reissue").permitAll()
                 .antMatchers("/accounts/emailsignup").permitAll()
                 .antMatchers("/accounts/confirm-email").permitAll()
                 .antMatchers(SWAGGER_LIST).permitAll()

--- a/src/main/java/com/example/InstagramCloneCoding/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/config/SecurityConfig.java
@@ -31,12 +31,12 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.cors().disable()        // cors 방지
+        http.cors().disable()
                 .csrf().disable()        // csrf 방지
                 .formLogin().disable()
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션 사용x(jwt 사용)
-                .and()
-                .authorizeRequests()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS); // 세션 사용x(jwt 사용)
+
+        http.authorizeRequests()
                 .antMatchers("/auth/signin").permitAll() // 모든 요청 허가
                 .antMatchers("/auth/reissue").permitAll()
                 .antMatchers("/accounts/emailsignup").permitAll()

--- a/src/main/java/com/example/InstagramCloneCoding/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/config/SecurityConfig.java
@@ -37,8 +37,8 @@ public class SecurityConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션 사용x(jwt 사용)
                 .and()
                 .authorizeRequests()
-                .antMatchers("/signin").permitAll() // 모든 요청 허가
-                .antMatchers("/reissue").permitAll()
+                .antMatchers("auth/signin").permitAll() // 모든 요청 허가
+                .antMatchers("auth/reissue").permitAll()
                 .antMatchers("/accounts/emailsignup").permitAll()
                 .antMatchers("/accounts/confirm-email").permitAll()
                 .antMatchers(SWAGGER_LIST).permitAll()

--- a/src/main/java/com/example/InstagramCloneCoding/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/config/SwaggerConfig.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.apache.http.HttpHeaders;
 import org.springdoc.core.GroupedOpenApi;
-import org.springdoc.core.customizers.OpenApiCustomiser;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -35,6 +34,7 @@ public class SwaggerConfig {
                 .bearerFormat("Authorization")
                 .in(SecurityScheme.In.HEADER)
                 .name(HttpHeaders.AUTHORIZATION);
+
         // Security 요청 설정
         SecurityRequirement addSecurityItem = new SecurityRequirement().addList("Authorization");
 


### PR DESCRIPTION
## 개요
- 팔로우 기능 구현
- 언팔로우 기능 구현
- 팔로워, 팔로잉, 맞팔로우 하고 있는 계정 리스트 리턴 구현
- 아이디 존재하는지 검색 기능 구현

## 작업사항
- 아이디 검색 시 존재하면 "exist"문자열 리턴, 아닐 시 예외처리
- 팔로우 요청 시 이미 팔로우 되어있으면 예외처리, 아닐 시 정상 처리( 팔로우 요청한 아이디가 존재하지 않으면 예외처리)
- 언팔로우 요청시 현재 팔로우 되어있는지 검사 -> 되어있으면 정상처리, 아닐 시 예외처리
- 맞팔로우 계정 요청 시 팔로워, 팔로잉 계정 가져와 retainAll()로 중복되는것만 골라 리턴

## 변경로직
- 로그인 인증 부분의 url 변경 (앞에 "/auth" 붙여줌)
- refresh token 으로 access token 재발급 받을 시 refresh token이 만료되었을 때의 예외처리 안되어있는 것 추가하여 구현함