### PR TITLE
포스트 작성 기능

### DIFF
--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberAccountsApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberAccountsApiController.java
@@ -1,6 +1,5 @@
 package com.example.InstagramCloneCoding.domain.member.api;
 
-import com.example.InstagramCloneCoding.domain.member.application.AwsS3Service;
 import com.example.InstagramCloneCoding.domain.member.application.EmailConfirmService;
 import com.example.InstagramCloneCoding.domain.member.application.MemberService;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
@@ -12,7 +11,6 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.transaction.Transactional;
 
-
 @RestController
 @RequestMapping("accounts/")
 @Transactional
@@ -23,9 +21,8 @@ public class MemberAccountsApiController {
 
     private final EmailConfirmService emailConfirmService;
 
-
     @PostMapping("emailsignup")
-    public ResponseEntity<Member> register(@RequestBody MemberRegisterDto registerDto) {
+    public ResponseEntity<String> register(@RequestBody MemberRegisterDto registerDto) {
         // 회원가입 (member 테이블에 추가)
         Member member = memberService.register(registerDto);
 
@@ -33,13 +30,14 @@ public class MemberAccountsApiController {
         emailConfirmService.createEmailConfirmationToken(member.getUserId(), member.getEmail());
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(member);
+                .body(member.getUserId());
     }
 
     @GetMapping("confirm-email")
     public ResponseEntity<Member> confirmEmail(@RequestParam String token) {
         // 이메일 인증 완료하고 member 테이블의 email_verified 컬럼 true로 바꿔주기
+        emailConfirmService.confirmEmail(token);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(emailConfirmService.confirmEmail(token));
+                .build();
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberAccountsApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberAccountsApiController.java
@@ -5,6 +5,7 @@ import com.example.InstagramCloneCoding.domain.member.application.EmailConfirmSe
 import com.example.InstagramCloneCoding.domain.member.application.MemberService;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.member.dto.MemberRegisterDto;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,13 +18,14 @@ import javax.transaction.Transactional;
 @RestController
 @RequestMapping("accounts/")
 @Transactional
+@RequiredArgsConstructor
 public class MemberAccountsApiController {
 
-    @Autowired
+
     private MemberService memberService;
-    @Autowired
+
     private EmailConfirmService emailConfirmService;
-    @Autowired
+
     private AwsS3Service awsS3Service;
 
     @PostMapping("emailsignup")
@@ -43,15 +45,5 @@ public class MemberAccountsApiController {
         // 이메일 인증 완료하고 member 테이블의 email_verified 컬럼 true로 바꿔주기
         return ResponseEntity.status(HttpStatus.OK)
                 .body(emailConfirmService.confirmEmail(token));
-    }
-
-    @PostMapping("edit/profile-image")
-    public ResponseEntity<String> changeProfileImage(@RequestParam("image") MultipartFile multipartFile,
-                                                     @RequestParam("userId") String userId) {
-        String imagePath = awsS3Service.upload(multipartFile);
-
-        memberService.changeProfileImage(userId, imagePath);
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(imagePath);
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberAccountsApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberAccountsApiController.java
@@ -6,11 +6,9 @@ import com.example.InstagramCloneCoding.domain.member.application.MemberService;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.member.dto.MemberRegisterDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.transaction.Transactional;
 
@@ -21,12 +19,10 @@ import javax.transaction.Transactional;
 @RequiredArgsConstructor
 public class MemberAccountsApiController {
 
+    private final MemberService memberService;
 
-    private MemberService memberService;
+    private final EmailConfirmService emailConfirmService;
 
-    private EmailConfirmService emailConfirmService;
-
-    private AwsS3Service awsS3Service;
 
     @PostMapping("emailsignup")
     public ResponseEntity<Member> register(@RequestBody MemberRegisterDto registerDto) {

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberEditApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberEditApiController.java
@@ -5,14 +5,16 @@ import com.example.InstagramCloneCoding.domain.member.application.AwsS3Service;
 import com.example.InstagramCloneCoding.domain.member.application.MemberService;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.global.common.annotation.LoggedInUser;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.transaction.Transactional;
+import java.util.List;
 
 @RestController
 @RequestMapping("edit/")
@@ -24,12 +26,13 @@ public class MemberEditApiController {
 
     private final MemberService memberService;
 
-    @PostMapping("profile-image")
-    public ResponseEntity<String> changeProfileImage(@RequestParam("image") MultipartFile multipartFile,
-                                                     @LoggedInUser Member member) {
-        String imagePath = awsS3Service.upload(multipartFile);
+    @PostMapping(value = "profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<String> changeProfileImage(@Parameter(hidden = true) @LoggedInUser Member member,
+                                                     @RequestPart("image") List<MultipartFile> multipartFile) {
+        String imagePath = awsS3Service.uploadFile(multipartFile).get(0);
 
         memberService.changeProfileImage(member.getUserId(), imagePath);
+
         return ResponseEntity.status(HttpStatus.OK)
                 .body(imagePath);
     }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberEditApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberEditApiController.java
@@ -1,0 +1,37 @@
+package com.example.InstagramCloneCoding.domain.member.api;
+
+
+import com.example.InstagramCloneCoding.domain.member.application.AwsS3Service;
+import com.example.InstagramCloneCoding.domain.member.application.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.transaction.Transactional;
+
+@RestController
+@RequestMapping("edit/")
+@Transactional
+@RequiredArgsConstructor
+public class MemberEditApiController {
+
+    private final AwsS3Service awsS3Service;
+
+    private final MemberService memberService;
+
+    @PostMapping("profile-image")
+    public ResponseEntity<String> changeProfileImage(@RequestParam("image") MultipartFile multipartFile,
+                                                     @RequestParam("userId") String userId) {
+        String imagePath = awsS3Service.upload(multipartFile);
+
+        memberService.changeProfileImage(userId, imagePath);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(imagePath);
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberEditApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberEditApiController.java
@@ -3,14 +3,13 @@ package com.example.InstagramCloneCoding.domain.member.api;
 
 import com.example.InstagramCloneCoding.domain.member.application.AwsS3Service;
 import com.example.InstagramCloneCoding.domain.member.application.MemberService;
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.global.common.annotation.LoggedInUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.transaction.Transactional;
@@ -27,10 +26,10 @@ public class MemberEditApiController {
 
     @PostMapping("profile-image")
     public ResponseEntity<String> changeProfileImage(@RequestParam("image") MultipartFile multipartFile,
-                                                     @RequestParam("userId") String userId) {
+                                                     @LoggedInUser Member member) {
         String imagePath = awsS3Service.upload(multipartFile);
 
-        memberService.changeProfileImage(userId, imagePath);
+        memberService.changeProfileImage(member.getUserId(), imagePath);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(imagePath);
     }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/AwsS3Service.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/AwsS3Service.java
@@ -21,7 +21,7 @@ import static com.example.InstagramCloneCoding.domain.member.error.MemberErrorCo
 @RequiredArgsConstructor
 public class AwsS3Service {
 
-    private AmazonS3 amazonS3;
+    private final AmazonS3 amazonS3;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/AwsS3Service.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/AwsS3Service.java
@@ -6,12 +6,13 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.example.InstagramCloneCoding.global.error.RestApiException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import static com.example.InstagramCloneCoding.domain.member.error.MemberErrorCode.IMAGE_UPLOAD_FAIL;
@@ -26,22 +27,29 @@ public class AwsS3Service {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String upload(MultipartFile multipartFile) {
-        String s3FileName = UUID.randomUUID() + "-" + multipartFile.getOriginalFilename(); // 이름 중복 피하기
+    public List<String> uploadFile(List<MultipartFile> multipartFiles) {
+        List<String> fileNameList = new ArrayList<>();
 
-        try {
-            ObjectMetadata objMeta = new ObjectMetadata();
-            objMeta.setContentLength(multipartFile.getInputStream().available());
+        multipartFiles.forEach(file -> {
+            String s3FileName = UUID.randomUUID() + "-" + file.getOriginalFilename(); // 이름 중복 피하기
 
-            // s3 버킷에 업로드
-            amazonS3.putObject(
-                    new PutObjectRequest(bucket, s3FileName, multipartFile.getInputStream(), objMeta)
-                            .withCannedAcl(CannedAccessControlList.PublicRead) // 업로드되는 파일에 public read 권한 부여
-            );
-        } catch (Exception e) {
-            throw new RestApiException(IMAGE_UPLOAD_FAIL);
-        }
+            try {
+                ObjectMetadata objMeta = new ObjectMetadata();
+                objMeta.setContentLength(file.getInputStream().available());
 
-        return amazonS3.getUrl(bucket, s3FileName).toString();
+                // s3 버킷에 업로드
+                amazonS3.putObject(
+                        new PutObjectRequest(bucket, s3FileName, file.getInputStream(), objMeta)
+                                .withCannedAcl(CannedAccessControlList.PublicRead) // 업로드되는 파일에 public read 권한 부여
+                );
+                file.getInputStream().close();
+            } catch (Exception e) {
+                throw new RestApiException(IMAGE_UPLOAD_FAIL);
+            }
+
+            fileNameList.add(amazonS3.getUrl(bucket, s3FileName).toString());
+        });
+
+        return fileNameList;
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/AwsS3Service.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/AwsS3Service.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.example.InstagramCloneCoding.global.error.RestApiException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -17,9 +18,9 @@ import static com.example.InstagramCloneCoding.domain.member.error.MemberErrorCo
 
 @Service
 @Transactional
+@RequiredArgsConstructor
 public class AwsS3Service {
 
-    @Autowired
     private AmazonS3 amazonS3;
 
     @Value("${cloud.aws.s3.bucket}")

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailConfirmService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailConfirmService.java
@@ -6,7 +6,6 @@ import com.example.InstagramCloneCoding.domain.member.domain.EmailConfirmationTo
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.global.error.RestApiException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailConfirmService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailConfirmService.java
@@ -5,6 +5,7 @@ import com.example.InstagramCloneCoding.domain.member.dao.MemberRepository;
 import com.example.InstagramCloneCoding.domain.member.domain.EmailConfirmationToken;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.global.error.RestApiException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.stereotype.Service;
@@ -17,13 +18,13 @@ import static com.example.InstagramCloneCoding.domain.member.error.MemberErrorCo
 
 @Service
 @Transactional
+@RequiredArgsConstructor
 public class EmailConfirmService {
 
-    @Autowired
     private MemberRepository memberRepository;
-    @Autowired
+
     private EmailConfirmationTokenRepository emailConfirmationTokenRepository;
-    @Autowired
+
     private EmailSenderService emailSenderService;
 
     public String createEmailConfirmationToken(String userId, String receiverEmail) {

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailConfirmService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailConfirmService.java
@@ -21,11 +21,11 @@ import static com.example.InstagramCloneCoding.domain.member.error.MemberErrorCo
 @RequiredArgsConstructor
 public class EmailConfirmService {
 
-    private MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
 
-    private EmailConfirmationTokenRepository emailConfirmationTokenRepository;
+    private final EmailConfirmationTokenRepository emailConfirmationTokenRepository;
 
-    private EmailSenderService emailSenderService;
+    private final EmailSenderService emailSenderService;
 
     public String createEmailConfirmationToken(String userId, String receiverEmail) {
         EmailConfirmationToken token = EmailConfirmationToken.createEmailConfirmationToken(userId);

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailSenderService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailSenderService.java
@@ -1,5 +1,6 @@
 package com.example.InstagramCloneCoding.domain.member.application;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -7,9 +8,9 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class EmailSenderService {
 
-    @Autowired
     private JavaMailSender javaMailSender;
 
     @Async

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailSenderService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailSenderService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class EmailSenderService {
 
-    private JavaMailSender javaMailSender;
+    private final JavaMailSender javaMailSender;
 
     @Async
     public void sendEmail(SimpleMailMessage email) {

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailSenderService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailSenderService.java
@@ -1,7 +1,6 @@
 package com.example.InstagramCloneCoding.domain.member.application;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.scheduling.annotation.Async;

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
@@ -19,9 +19,9 @@ import static com.example.InstagramCloneCoding.domain.member.error.MemberErrorCo
 @RequiredArgsConstructor
 public class MemberService {
 
-    private MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
 
-    private PasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder;
 
     public Member register(MemberRegisterDto registerDto) {
         // 아이디 중복 확인

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
@@ -6,7 +6,6 @@ import com.example.InstagramCloneCoding.domain.member.dto.MemberRegisterDto;
 import com.example.InstagramCloneCoding.domain.member.error.MemberErrorCode;
 import com.example.InstagramCloneCoding.global.error.RestApiException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
@@ -5,6 +5,7 @@ import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.member.dto.MemberRegisterDto;
 import com.example.InstagramCloneCoding.domain.member.error.MemberErrorCode;
 import com.example.InstagramCloneCoding.global.error.RestApiException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -15,11 +16,11 @@ import static com.example.InstagramCloneCoding.domain.member.error.MemberErrorCo
 
 @Service
 @Transactional
+@RequiredArgsConstructor
 public class MemberService {
 
-    @Autowired
     private MemberRepository memberRepository;
-    @Autowired
+
     private PasswordEncoder passwordEncoder;
 
     public Member register(MemberRegisterDto registerDto) {

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/EmailConfirmationToken.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/EmailConfirmationToken.java
@@ -38,10 +38,6 @@ public class EmailConfirmationToken {
     @Column(name = "created_date")
     private LocalDateTime createdDate;
 
-/*    @LastModifiedDate
-    @Column
-    private LocalDateTime lastModifiedDate;*/
-
     public static EmailConfirmationToken createEmailConfirmationToken(String userId) {
         EmailConfirmationToken token = new EmailConfirmationToken();
         token.setExpirationDate(LocalDateTime.now().plusMinutes(EMAIL_TOKEN_EXPIRATION_TIME_VALUE));

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
@@ -37,8 +37,8 @@ public class Member {
     @Column(name = "email_verified", nullable = false)
     boolean emailVerified;
 
-//    @OneToMany(mappedBy = "member")
-//    private List<Post> posts = new ArrayList<>();
+    @OneToMany(mappedBy = "member")
+    private List<Post> posts = new ArrayList<>();
 
     public Member(String email, String userId, String name, String password) {
         this.email = email;

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
@@ -1,13 +1,13 @@
 package com.example.InstagramCloneCoding.domain.member.domain;
 
+import com.example.InstagramCloneCoding.domain.post.domain.Post;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "member")
@@ -36,6 +36,9 @@ public class Member {
 
     @Column(name = "email_verified", nullable = false)
     boolean emailVerified;
+
+//    @OneToMany(mappedBy = "member")
+//    private List<Post> posts = new ArrayList<>();
 
     public Member(String email, String userId, String name, String password) {
         this.email = email;

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
@@ -1,0 +1,42 @@
+package com.example.InstagramCloneCoding.domain.post.api;
+
+import com.example.InstagramCloneCoding.domain.member.application.AwsS3Service;
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.domain.post.application.PostService;
+import com.example.InstagramCloneCoding.domain.post.domain.Post;
+import com.example.InstagramCloneCoding.global.common.annotation.LoggedInUser;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@RestController
+@RequestMapping("post/")
+@Transactional
+@RequiredArgsConstructor
+public class PostApiController {
+
+    private final PostService postService;
+
+    private final AwsS3Service awsS3Service;
+
+    @PostMapping(value = "write", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<List<String>> write(@Parameter(hidden = true) @LoggedInUser Member member,
+                                  @RequestPart("images") List<MultipartFile> images,
+                                  @RequestPart("content") String content) {
+        // s3 bucket에 이미지 업로드
+        List<String> fileNameList = awsS3Service.uploadFile(images);
+
+        // 데이터베이스에 저장
+        Post post = postService.uploadPost(member, content, fileNameList);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(fileNameList);
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
@@ -29,7 +29,7 @@ public class PostApiController {
     @PostMapping(value = "write", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<List<String>> write(@Parameter(hidden = true) @LoggedInUser Member member,
                                   @RequestPart("images") List<MultipartFile> images,
-                                  @RequestPart("content") String content) {
+                                  @RequestPart(value = "content", required = false) String content) {
         // s3 bucket에 이미지 업로드
         List<String> fileNameList = awsS3Service.uploadFile(images);
 

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/application/PostService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/application/PostService.java
@@ -1,0 +1,36 @@
+package com.example.InstagramCloneCoding.domain.post.application;
+
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.domain.post.dao.PostImageRepository;
+import com.example.InstagramCloneCoding.domain.post.dao.PostRepository;
+import com.example.InstagramCloneCoding.domain.post.domain.Post;
+import com.example.InstagramCloneCoding.domain.post.domain.PostImage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+
+    private final PostImageRepository postImageRepository;
+
+    public Post uploadPost(Member member, String content, List<String> fileNameList) {
+        // post 저장
+        Post post = new Post(member, content);
+        postRepository.save(post);
+
+        // post images 저장
+        fileNameList.forEach(fileName -> {
+            PostImage postImage = new PostImage(fileName, post);
+            postImageRepository.save(postImage);
+        });
+
+        return post;
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/dao/PostImageRepository.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/dao/PostImageRepository.java
@@ -1,0 +1,9 @@
+package com.example.InstagramCloneCoding.domain.post.dao;
+
+import com.example.InstagramCloneCoding.domain.post.domain.PostImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostImageRepository extends JpaRepository<PostImage, String> {
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/dao/PostRepository.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/dao/PostRepository.java
@@ -1,0 +1,9 @@
+package com.example.InstagramCloneCoding.domain.post.dao;
+
+import com.example.InstagramCloneCoding.domain.post.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Integer> {
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/domain/Post.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/domain/Post.java
@@ -1,0 +1,39 @@
+package com.example.InstagramCloneCoding.domain.post.domain;
+
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.joda.time.DateTime;
+import org.springframework.data.annotation.CreatedDate;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "post")
+@Getter @Setter
+@NoArgsConstructor
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id", nullable = false)
+    private int postId;
+
+    @Column(name = "content", nullable = true)
+    private String content;
+
+    @CreatedDate
+    @Column(name = "create_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private Member member;
+
+    @OneToMany(mappedBy = "post")
+    private List<PostImage> postImages = new ArrayList<>();
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/domain/Post.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/domain/Post.java
@@ -4,8 +4,8 @@ import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.joda.time.DateTime;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -16,6 +16,7 @@ import java.util.List;
 @Table(name = "post")
 @Getter @Setter
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class Post {
 
     @Id
@@ -27,7 +28,7 @@ public class Post {
     private String content;
 
     @CreatedDate
-    @Column(name = "create_at", nullable = false)
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
     @ManyToOne
@@ -36,4 +37,9 @@ public class Post {
 
     @OneToMany(mappedBy = "post")
     private List<PostImage> postImages = new ArrayList<>();
+
+    public Post(Member member, String content) {
+        this.member = member;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/domain/PostImage.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/domain/PostImage.java
@@ -14,11 +14,15 @@ import javax.persistence.*;
 public class PostImage {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_image_id", nullable = false)
-    private int postImageId;
+    private String postImageId;
 
     @ManyToOne
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
+
+    public PostImage(String postImageId, Post post) {
+        this.postImageId = postImageId;
+        this.post = post;
+    }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/domain/PostImage.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/domain/PostImage.java
@@ -1,0 +1,24 @@
+package com.example.InstagramCloneCoding.domain.post.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "post_image")
+@Getter
+@Setter
+@NoArgsConstructor
+public class PostImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_image_id", nullable = false)
+    private int postImageId;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+}

--- a/src/main/java/com/example/InstagramCloneCoding/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/config/SecurityConfig.java
@@ -39,8 +39,7 @@ public class SecurityConfig {
                 .authorizeRequests()
                 .antMatchers("/signin").permitAll() // 모든 요청 허가
                 .antMatchers("/reissue").permitAll()
-                .antMatchers("/accounts/emailsignup").permitAll()
-                .antMatchers("/accounts/confirm-email").permitAll()
+                .antMatchers("/accounts/**").permitAll()
                 .antMatchers(SWAGGER_LIST).permitAll()
                 .anyRequest().authenticated()   // 나머지 인증 필요
                 .and()

--- a/src/main/java/com/example/InstagramCloneCoding/global/config/WebMvcConfig.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/config/WebMvcConfig.java
@@ -15,7 +15,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
 
-    @Autowired
     private final LoggedInUserArgumentResolver loggedInUserArgumentResolver;
 
     @Override


### PR DESCRIPTION
## 개요
포스트 작성 기능 구현

## 작업사항
- post/write 경로에 multipart/form-data 콘텐트타입으로 images에 이미지파일, content에 텍스트를 form 형식으로 담아 post 요청을 보내면 포스팅이 완료됨.
- 구현하기 위해 Post, PostImage, PostApiController, PostService, PostRepository, PostImageRepository 작성. post와 post_image는 따로 쓰일 일이 없을 것 같아서 post라는 하나의 패키지에 담음.
- Member 클래스에 List<Post> posts 필드를 추가하고 @OneToMany의 mappedBy 속성을 이용하여 Post와 연관관계 매핑이 되도록 함.
- Member 클래스에 List 타입의 필드가 추가되면서 요청이 왔을 때 Member 클래스를 그대로 바디에 넣어 응답하면 오류가 나기 때문에 일단 임시 방편으로 member id를 바디에 넣어 응답하는 것으로 수정함. 추후 dto를 따로 만들던지, 뷰 리졸버를 추가하던지 해서 수정할 예정.. 같은 문제로 /post/write에 요청이 들어왔을 때도 우선 이미지 경로 리스트만 반환하고 있는데 이 역시 수정할 예정.

## 변경로직
- @RequiredArgsConstructor 어노테이션을 클래스에 추가하고 @Autowired  어노테이션 제거
- AwsS3Service 클래스의 uploadFile 메소드의 인자를 MultipartFile multipartFile에서 List<MultipartFIle> multipartFiles로 변경하여 한 번에 여러 개의 이미지를 s3 버킷에 업로드할 수 있도록 함.
