### PR TITLE
홈화면 게시물 구현

### DIFF
--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/api/FollowApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/api/FollowApiController.java
@@ -1,8 +1,8 @@
 package com.example.InstagramCloneCoding.domain.follow.api;
 
+import com.example.InstagramCloneCoding.domain.follow.application.FollowFindService;
 import com.example.InstagramCloneCoding.domain.follow.application.FollowService;
 import com.example.InstagramCloneCoding.domain.follow.dto.FollowDto;
-import com.example.InstagramCloneCoding.domain.member.application.MemberService;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.global.common.annotation.LoggedInUser;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,20 +19,11 @@ import java.util.List;
 public class FollowApiController {
 
     private final FollowService followService;
-    private final MemberService memberService;
-
-    @GetMapping("/searchmember")
-    public ResponseEntity<String> searchMember(@RequestParam String userId) {
-        memberService.findMember(userId);
-
-        return ResponseEntity.status(HttpStatus.OK)
-                .body("member exist");
-    }
+    private final FollowFindService followFindService;
 
     @PostMapping("/follow")
     public ResponseEntity<String> follow(@Parameter(hidden = true) @LoggedInUser Member member, @RequestBody FollowDto followDto) {
-        Member following = memberService.findMember(followDto.getFollowingOrFollowerId());
-        followService.follow(member, following);
+        followService.follow(member, followDto.getFollowingOrFollowerId());
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body("following success!");
@@ -40,8 +31,7 @@ public class FollowApiController {
 
     @DeleteMapping("/unfollow")
     public ResponseEntity<String> unfollow(@Parameter(hidden = true) @LoggedInUser Member member, @RequestBody FollowDto followDto) {
-        Member following = memberService.findMember(followDto.getFollowingOrFollowerId());
-        followService.unfollow(member, following);
+        followService.unfollow(member, followDto.getFollowingOrFollowerId());
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body("unfollow success!");
@@ -49,28 +39,25 @@ public class FollowApiController {
 
     @GetMapping("/getfollowers")
     public ResponseEntity<List<String>> followers(@Parameter(hidden = true) @LoggedInUser Member member) {
-        List<Member> followers = followService.getFollowers(member);
-        List<String> followerIds = followService.getIds(followers);
+        List<String> followersId = followFindService.getFollowersId(member);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(followerIds);
+                .body(followersId);
     }
 
     @GetMapping("/getfollowings")
     public ResponseEntity<List<String>> followings(@Parameter(hidden = true) @LoggedInUser Member member) {
-        List<Member> followings = followService.getFollowings(member);
-        List<String> followingIds = followService.getIds(followings);
+        List<String> followingsId = followFindService.getFollowingsId(member);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(followingIds);
+                .body(followingsId);
     }
 
     @GetMapping("/getfollowbacks")
     public ResponseEntity<List<String>> followBack(@Parameter(hidden = true) @LoggedInUser Member member) {
-        List<Member> friends = followService.getFollowBacks(member);
-        List<String> friendIds = followService.getIds(friends);
+        List<String> friendsId = followFindService.getFollowingBacksId(member);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(friendIds);
+                .body(friendsId);
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/api/FollowApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/api/FollowApiController.java
@@ -49,25 +49,28 @@ public class FollowApiController {
 
     @GetMapping("/getfollowers")
     public ResponseEntity<List<String>> followers(@Parameter(hidden = true) @LoggedInUser Member member) {
-        List<String> followers = followService.getFollowers(member);
+        List<Member> followers = followService.getFollowers(member);
+        List<String> followerIds = followService.getIds(followers);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(followers);
+                .body(followerIds);
     }
 
     @GetMapping("/getfollowings")
     public ResponseEntity<List<String>> followings(@Parameter(hidden = true) @LoggedInUser Member member) {
-        List<String> followings = followService.getFollowings(member);
+        List<Member> followings = followService.getFollowings(member);
+        List<String> followingIds = followService.getIds(followings);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(followings);
+                .body(followingIds);
     }
 
     @GetMapping("/getfollowbacks")
     public ResponseEntity<List<String>> followBack(@Parameter(hidden = true) @LoggedInUser Member member) {
-        List<String> friends = followService.getFollowBacks(member);
+        List<Member> friends = followService.getFollowBacks(member);
+        List<String> friendIds = followService.getIds(friends);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(friends);
+                .body(friendIds);
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowFindService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowFindService.java
@@ -1,0 +1,42 @@
+package com.example.InstagramCloneCoding.domain.follow.application;
+
+import com.example.InstagramCloneCoding.domain.member.application.MemberFindService;
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FollowFindService {
+
+    private final MemberFindService memberFindService;
+
+    public List<String> getFollowersId(Member member) {
+        List<Member> followers = memberFindService.findFollowers(member);
+
+        return getIds(followers);
+    }
+
+    public List<String> getFollowingsId(Member member) {
+        List<Member> followings = memberFindService.findFollowings(member);
+
+        return getIds(followings);
+    }
+
+    public List<String> getFollowingBacksId(Member member) {
+        List<Member> friends = memberFindService.findFollowBacks(member);
+
+        return getIds(friends);
+    }
+
+    private List<String> getIds(List<Member> friends) {
+        return friends.stream()
+                .map(Member::getUserId)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowService.java
@@ -2,14 +2,12 @@ package com.example.InstagramCloneCoding.domain.follow.application;
 
 import com.example.InstagramCloneCoding.domain.follow.dao.FollowRepository;
 import com.example.InstagramCloneCoding.domain.follow.domain.Follow;
+import com.example.InstagramCloneCoding.domain.member.application.MemberFindService;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.global.error.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.example.InstagramCloneCoding.domain.follow.error.FollowError.ALREADY_FOLLOWING;
 import static com.example.InstagramCloneCoding.domain.follow.error.FollowError.NOT_FOLLOWING;
@@ -20,9 +18,12 @@ import static com.example.InstagramCloneCoding.domain.follow.error.FollowError.N
 public class FollowService {
 
     private final FollowRepository followRepository;
+    private final MemberFindService memberFindService;
 
     @Transactional
-    public void follow(Member follower, Member following) {
+    public void follow(Member follower, String followingId) {
+        Member following = memberFindService.findMember(followingId);
+
         // follow 중복 검사
         followRepository.findByFollowerAndFollowing(follower, following)
                 .ifPresent(x -> {
@@ -33,7 +34,9 @@ public class FollowService {
     }
 
     @Transactional
-    public void unfollow(Member follower, Member following) {
+    public void unfollow(Member follower, String followingId) {
+        Member following = memberFindService.findMember(followingId);
+
         Follow follow = followRepository.findByFollowerAndFollowing(follower, following).orElse(null);
         // follow 확인
         if (follow == null) {
@@ -41,33 +44,5 @@ public class FollowService {
         }
 
         followRepository.delete(follow);
-    }
-
-    public List<Member> getFollowers(Member member) {
-        List<Follow> followerList = member.getFollowers();
-
-        return followerList.stream()
-                .map(Follow::getFollower)
-                .collect(Collectors.toList());
-    }
-
-    public List<Member> getFollowings(Member member) {
-        List<Follow> followingList = member.getFollowings();
-
-        return followingList.stream()
-                .map(Follow::getFollowing)
-                .collect(Collectors.toList());
-    }
-
-    public List<Member> getFollowBacks(Member member) {
-        List<Member> followBackList = getFollowings(member);
-        followBackList.retainAll(getFollowers(member));
-        return followBackList;
-    }
-
-    public List<String> getIds(List<Member> friends) {
-        return friends.stream()
-                .map(Member::getUserId)
-                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowService.java
@@ -43,25 +43,31 @@ public class FollowService {
         followRepository.delete(follow);
     }
 
-    public List<String> getFollowers(Member member) {
+    public List<Member> getFollowers(Member member) {
         List<Follow> followerList = member.getFollowers();
 
         return followerList.stream()
-                .map(x -> x.getFollower().getUserId())
+                .map(Follow::getFollower)
                 .collect(Collectors.toList());
     }
 
-    public List<String> getFollowings(Member member) {
+    public List<Member> getFollowings(Member member) {
         List<Follow> followingList = member.getFollowings();
 
         return followingList.stream()
-                .map(x -> x.getFollowing().getUserId())
+                .map(Follow::getFollowing)
                 .collect(Collectors.toList());
     }
 
-    public List<String> getFollowBacks(Member member) {
-        List<String> followBackList = getFollowings(member);
+    public List<Member> getFollowBacks(Member member) {
+        List<Member> followBackList = getFollowings(member);
         followBackList.retainAll(getFollowers(member));
         return followBackList;
+    }
+
+    public List<String> getIds(List<Member> friends) {
+        return friends.stream()
+                .map(Member::getUserId)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/home/api/HomeApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/home/api/HomeApiController.java
@@ -23,7 +23,7 @@ public class HomeApiController {
     private final HomeService homeService;
     private final FollowService followService;
 
-    @GetMapping("/Posts")
+    @GetMapping("/posts")
     public ResponseEntity<List<PostResponseDto>> getPosts(@Parameter(hidden = true) @LoggedInUser Member member) {
         List<Member> followers = followService.getFollowers(member);
         List<PostResponseDto> posts = homeService.getHomePosts(member, followers);

--- a/src/main/java/com/example/InstagramCloneCoding/domain/home/api/HomeApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/home/api/HomeApiController.java
@@ -1,0 +1,34 @@
+package com.example.InstagramCloneCoding.domain.home.api;
+
+import com.example.InstagramCloneCoding.domain.follow.application.FollowService;
+import com.example.InstagramCloneCoding.domain.home.application.HomeService;
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.domain.post.dto.PostResponseDto;
+import com.example.InstagramCloneCoding.global.common.annotation.LoggedInUser;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/home")
+@RequiredArgsConstructor
+public class HomeApiController {
+
+    private final HomeService homeService;
+    private final FollowService followService;
+
+    @GetMapping("/homePosts")
+    public ResponseEntity<List<PostResponseDto>> getPosts(@Parameter(hidden = true) @LoggedInUser Member member) {
+        List<Member> followers = followService.getFollowers(member);
+        List<PostResponseDto> posts = homeService.getHomePosts(member, followers);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(posts);
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/home/api/HomeApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/home/api/HomeApiController.java
@@ -23,7 +23,7 @@ public class HomeApiController {
     private final HomeService homeService;
     private final FollowService followService;
 
-    @GetMapping("/homePosts")
+    @GetMapping("/Posts")
     public ResponseEntity<List<PostResponseDto>> getPosts(@Parameter(hidden = true) @LoggedInUser Member member) {
         List<Member> followers = followService.getFollowers(member);
         List<PostResponseDto> posts = homeService.getHomePosts(member, followers);

--- a/src/main/java/com/example/InstagramCloneCoding/domain/home/api/HomeApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/home/api/HomeApiController.java
@@ -21,12 +21,10 @@ import java.util.List;
 public class HomeApiController {
 
     private final HomeService homeService;
-    private final FollowService followService;
 
     @GetMapping("/posts")
     public ResponseEntity<List<PostResponseDto>> getPosts(@Parameter(hidden = true) @LoggedInUser Member member) {
-        List<Member> followers = followService.getFollowers(member);
-        List<PostResponseDto> posts = homeService.getHomePosts(member, followers);
+        List<PostResponseDto> posts = homeService.getHomePosts(member);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(posts);

--- a/src/main/java/com/example/InstagramCloneCoding/domain/home/application/HomeService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/home/application/HomeService.java
@@ -20,8 +20,8 @@ public class HomeService {
     private final PostRepository postRepository;
 
     public List<PostResponseDto> getHomePosts(Member member, List<Member> followers){
-        List<Post> posts = postRepository.findByMemberInAndCreatedAtGreaterThanEqual(followers, member.getLastHomeAccessed());
-        member.setLastHomeAccessed(LocalDateTime.now());
+        List<Post> posts = postRepository.findByMemberInAndCreatedAtGreaterThanEqual(followers, member.getLastHomeAccessTime());
+        member.setLastHomeAccessTime(LocalDateTime.now());
 
         return posts.stream()
                 .map(post->PostResponseDto.builder()

--- a/src/main/java/com/example/InstagramCloneCoding/domain/home/application/HomeService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/home/application/HomeService.java
@@ -1,5 +1,6 @@
 package com.example.InstagramCloneCoding.domain.home.application;
 
+import com.example.InstagramCloneCoding.domain.member.application.MemberFindService;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.post.dao.PostRepository;
 import com.example.InstagramCloneCoding.domain.post.domain.Post;
@@ -18,13 +19,17 @@ import java.util.stream.Collectors;
 public class HomeService {
 
     private final PostRepository postRepository;
+    private final MemberFindService memberFindService;
 
-    public List<PostResponseDto> getHomePosts(Member member, List<Member> followers){
-        List<Post> posts = postRepository.findByMemberInAndCreatedAtGreaterThanEqual(followers, member.getLastHomeAccessTime());
+    public List<PostResponseDto> getHomePosts(Member member) {
+        List<Post> posts = postRepository.findByMemberInAndCreatedAtGreaterThanEqual(
+                memberFindService.findFollowers(member),
+                member.getLastHomeAccessTime());
+
         member.setLastHomeAccessTime(LocalDateTime.now());
 
         return posts.stream()
-                .map(post->PostResponseDto.builder()
+                .map(post -> PostResponseDto.builder()
                         .postId(post.getPostId())
                         .authorId(post.getMember().getUserId())
                         .content(post.getContent())

--- a/src/main/java/com/example/InstagramCloneCoding/domain/home/application/HomeService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/home/application/HomeService.java
@@ -1,0 +1,36 @@
+package com.example.InstagramCloneCoding.domain.home.application;
+
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.domain.post.dao.PostRepository;
+import com.example.InstagramCloneCoding.domain.post.domain.Post;
+import com.example.InstagramCloneCoding.domain.post.dto.PostResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class HomeService {
+
+    private final PostRepository postRepository;
+
+    public List<PostResponseDto> getHomePosts(Member member, List<Member> followers){
+        List<Post> posts = postRepository.findByMemberInAndCreatedAtGreaterThanEqual(followers, member.getLastHomeAccessed());
+        member.setLastHomeAccessed(LocalDateTime.now());
+
+        return posts.stream()
+                .map(post->PostResponseDto.builder()
+                        .postId(post.getPostId())
+                        .authorId(post.getMember().getUserId())
+                        .content(post.getContent())
+                        .createdAt(post.getCreatedAt())
+                        .postImages(post.getPostImages())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberFindService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberFindService.java
@@ -1,0 +1,48 @@
+package com.example.InstagramCloneCoding.domain.member.application;
+
+import com.example.InstagramCloneCoding.domain.follow.domain.Follow;
+import com.example.InstagramCloneCoding.domain.member.dao.MemberRepository;
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.global.error.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.InstagramCloneCoding.domain.member.error.MemberErrorCode.MEMBER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberFindService {
+    private final MemberRepository memberRepository;
+
+    public Member findMember(String userId) {
+        return memberRepository.findById(userId)
+                .orElseThrow(() -> new RestApiException(MEMBER_NOT_FOUND));
+    }
+
+    public List<Member> findFollowers(Member member) {
+        List<Follow> followerList = member.getFollowers();
+
+        return followerList.stream()
+                .map(Follow::getFollower)
+                .collect(Collectors.toList());
+    }
+
+    public List<Member> findFollowings(Member member) {
+        List<Follow> followingList = member.getFollowings();
+
+        return followingList.stream()
+                .map(Follow::getFollowing)
+                .collect(Collectors.toList());
+    }
+
+    public List<Member> findFollowBacks(Member member) {
+        List<Member> followBackList = findFollowings(member);
+        followBackList.retainAll(findFollowers(member));
+        return followBackList;
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
@@ -50,7 +50,7 @@ public class MemberService {
                 .userId(registerDto.getUserId())
                 .name(registerDto.getName())
                 .password(encodedPassword)
-                .lastHomeAccessed(LocalDateTime.now())
+                .lastHomeAccessTime(LocalDateTime.now())
                 .build();
 
         return memberRepository.save(member);

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
@@ -65,14 +65,5 @@ public class MemberService {
         member.setProfileImage(imagePath);
         memberRepository.save(member);
     }
-
-    public Member findMember(String userId) {
-        Member member = memberRepository.findById(userId).orElse(null);
-        if (member == null) {
-            throw new RestApiException(MEMBER_NOT_FOUND);
-        }
-
-        return member;
-    }
 }
 

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
@@ -10,6 +10,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.time.LocalDateTime;
 
 import static com.example.InstagramCloneCoding.domain.member.error.MemberErrorCode.MEMBER_NOT_FOUND;
 
@@ -44,7 +45,14 @@ public class MemberService {
         String encodedPassword = passwordEncoder.encode(registerDto.getPassword());
 
         // 저장
-        member = new Member(registerDto.getEmail(), registerDto.getUserId(), registerDto.getName(), encodedPassword);
+        member = Member.builder()
+                .email(registerDto.getEmail())
+                .userId(registerDto.getUserId())
+                .name(registerDto.getName())
+                .password(encodedPassword)
+                .lastHomeAccessed(LocalDateTime.now())
+                .build();
+
         return memberRepository.save(member);
     }
 

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
@@ -42,7 +42,7 @@ public class Member {
     boolean emailVerified;
 
     @Column(name = "last_home_access_time")
-    LocalDateTime lastHomeAccessed;
+    LocalDateTime lastHomeAccessTime;
 
     @OneToMany(mappedBy = "member")
     private List<Post> posts = new ArrayList<>();
@@ -54,12 +54,12 @@ public class Member {
     private List<Follow> followers = new ArrayList<>();
 
     @Builder
-    public Member(String email, String userId, String name, String password, LocalDateTime lastHomeAccessed) {
+    public Member(String email, String userId, String name, String password, LocalDateTime lastHomeAccessTime) {
         this.email = email;
         this.userId = userId;
         this.name = name;
         this.password = password;
         this.emailVerified = false;
-        this.lastHomeAccessed = lastHomeAccessed;
+        this.lastHomeAccessTime = lastHomeAccessTime;
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
@@ -2,6 +2,7 @@ package com.example.InstagramCloneCoding.domain.member.domain;
 
 import com.example.InstagramCloneCoding.domain.follow.domain.Follow;
 import com.example.InstagramCloneCoding.domain.post.domain.Post;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -52,11 +53,13 @@ public class Member {
     @OneToMany(mappedBy = "following")
     private List<Follow> followers = new ArrayList<>();
 
-    public Member(String email, String userId, String name, String password) {
+    @Builder
+    public Member(String email, String userId, String name, String password, LocalDateTime lastHomeAccessed) {
         this.email = email;
         this.userId = userId;
         this.name = name;
         this.password = password;
         this.emailVerified = false;
+        this.lastHomeAccessed = lastHomeAccessed;
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,6 +39,9 @@ public class Member {
 
     @Column(name = "email_verified", nullable = false)
     boolean emailVerified;
+
+    @Column(name = "last_home_access_time")
+    LocalDateTime lastHomeAccessed;
 
     @OneToMany(mappedBy = "member")
     private List<Post> posts = new ArrayList<>();

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/dao/PostRepository.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/dao/PostRepository.java
@@ -1,9 +1,15 @@
 package com.example.InstagramCloneCoding.domain.post.dao;
 
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Repository
 public interface PostRepository extends JpaRepository<Post, Integer> {
+
+    List<Post> findByMemberInAndCreatedAtGreaterThanEqual(List<Member> followers, LocalDateTime accessTime);
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/dto/PostResponseDto.java
@@ -1,0 +1,42 @@
+package com.example.InstagramCloneCoding.domain.post.dto;
+
+import com.example.InstagramCloneCoding.domain.post.domain.PostImage;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+public class PostResponseDto {
+
+    private int postId;
+
+    private String authorId;
+
+    private String content;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyyMMddHHmmss")
+    private LocalDateTime createdAt;
+
+    private List<String> postImages;
+
+    @Builder
+    public PostResponseDto(int postId, String authorId, String content, LocalDateTime createdAt, List<PostImage> postImages) {
+        this.postId = postId;
+        this.authorId = authorId;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.postImages = getPostImagesName(postImages);
+    }
+
+    private List<String> getPostImagesName(List<PostImage> postImages) {
+        return postImages.stream()
+                .map(PostImage::getPostImageId)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/global/common/resolver/LoggedInUserArgumentResolver.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/common/resolver/LoggedInUserArgumentResolver.java
@@ -1,6 +1,6 @@
 package com.example.InstagramCloneCoding.global.common.resolver;
 
-import com.example.InstagramCloneCoding.domain.member.application.MemberService;
+import com.example.InstagramCloneCoding.domain.member.dao.MemberRepository;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.global.common.annotation.LoggedInUser;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +17,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @RequiredArgsConstructor
 public class LoggedInUserArgumentResolver implements HandlerMethodArgumentResolver {
 
-    private final MemberService memberService;
+    private final MemberRepository memberRepository;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -36,6 +36,6 @@ public class LoggedInUserArgumentResolver implements HandlerMethodArgumentResolv
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        return memberService.findMember(authentication.getName());
+        return memberRepository.findById(authentication.getName()).orElse(null);
     }
 }


### PR DESCRIPTION
## 개요
홈 화면에 나올 게시물들 보내주는 기능 구현

## 작업사항
- member 테이블에 last_home_access_time (타입 : datetime) 추가함
- PostRepository에 member는 주어진 리스트에 존재하고, createAt은 크거나 같은 것을 탐색해주는 findByMemberInAndCreatedAtGreaterThanEqual(List<Member>, LocalDateTime)함수 추가함
    -> https://velog.io/@hongseoda/%EB%82%B4%EB%B0%B0%EC%BA%A0TIL614DATA-JPA-%EB%A9%94%EC%86%8C%EB%93%9C-%EC%9D%B4%EB%A6%84%EC%9C%BC%EB%A1%9C-%ED%95%A8%EC%88%98-%EB%A7%8C%EB%93%A4%EA%B8%B0 (jpa 메소드 명명규칙 참고 사이트) 
- home/posts 요청 시 가장 마지막으로 홈화면에 접근한 시간 이후로 작성된 follower들의 게시물들을 리턴해준다. 이 때, findByMemberInAndCreatedAtGreaterThanEqual함수를 사용하여 DB에서 탐색하고, LocalDateTime.now()를 이용하여 현재 시간을 LastHomeAccessTime에 넣어준다. 결과값은 List\<PostResponseDto\>에 담아서 리턴시킨다.
- LastHomeAccessTime를 변경할 때 @Transactional이 붙어있기 때문에 setter함수로만 바꿔줘도 transaction이 종료 될 때 자동으로 반영된다.(save.. 기타 등 따로 처리해주지 않아도 됨)

## 변경로직
- 회원가입 시 당시 시간을 LastHomeAccessTime에 집어 넣어 줌
- Member 엔티티 생성자를 @builder형식으로 변경(매개변수가 많아짐)
