### PR TITLE
포스트 읽기, 삭제 기능

### DIFF
--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberAccountsApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberAccountsApiController.java
@@ -4,6 +4,7 @@ import com.example.InstagramCloneCoding.domain.member.application.EmailConfirmSe
 import com.example.InstagramCloneCoding.domain.member.application.MemberService;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.member.dto.MemberRegisterDto;
+import com.example.InstagramCloneCoding.domain.member.dto.MemberResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,15 +23,15 @@ public class MemberAccountsApiController {
     private final EmailConfirmService emailConfirmService;
 
     @PostMapping("emailsignup")
-    public ResponseEntity<String> register(@RequestBody MemberRegisterDto registerDto) {
+    public ResponseEntity<MemberResponseDto> register(@RequestBody MemberRegisterDto registerDto) {
         // 회원가입 (member 테이블에 추가)
-        Member member = memberService.register(registerDto);
+        MemberResponseDto memberResponseDto = memberService.register(registerDto);
 
         // 이메일 인증 메일 보내기
-        emailConfirmService.createEmailConfirmationToken(member.getUserId(), member.getEmail());
+        emailConfirmService.createEmailConfirmationToken(memberResponseDto.getUserId(), memberResponseDto.getEmail());
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(member.getUserId());
+                .body(memberResponseDto);
     }
 
     @GetMapping("confirm-email")

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/AwsS3Service.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/AwsS3Service.java
@@ -2,6 +2,7 @@ package com.example.InstagramCloneCoding.domain.member.application;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.example.InstagramCloneCoding.global.error.RestApiException;
@@ -51,5 +52,9 @@ public class AwsS3Service {
         });
 
         return fileNameList;
+    }
+
+    public void deleteFile(String fileName) {
+        amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/AwsS3Service.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/AwsS3Service.java
@@ -31,7 +31,7 @@ public class AwsS3Service {
         List<String> fileNameList = new ArrayList<>();
 
         multipartFiles.forEach(file -> {
-            String s3FileName = UUID.randomUUID() + "-" + file.getOriginalFilename(); // 이름 중복 피하기
+            String s3FileName = UUID.randomUUID().toString(); // 이름 중복 피하기
 
             try {
                 ObjectMetadata objMeta = new ObjectMetadata();

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 
-import static com.example.InstagramCloneCoding.domain.member.error.MemberErrorCode.MEMBER_NOT_FOUND;
+import static com.example.InstagramCloneCoding.domain.member.error.MemberErrorCode.*;
 
 @Service
 @Transactional
@@ -25,27 +25,27 @@ public class MemberService {
 
     public MemberResponseDto register(MemberRegisterDto registerDto) {
         // 아이디 중복 확인
-        Member member = memberRepository.findById(registerDto.getUserId()).orElse(null);
-        if (member != null) {
-            throw new RestApiException(MemberErrorCode.ID_ALREADY_EXISTS);
-        }
+        memberRepository.findById(registerDto.getUserId())
+                .ifPresent(member -> {
+                    throw new RestApiException(ID_ALREADY_EXISTS);
+                });
 
         // 이메일 중복 확인
-        member = memberRepository.findByEmail(registerDto.getEmail()).orElse(null);
-        if (member != null) {
-            throw new RestApiException(MemberErrorCode.EMAIL_ALREADY_REGISTERED);
-        }
+        memberRepository.findByEmail(registerDto.getEmail())
+                .ifPresent(member -> {
+                    throw new RestApiException(EMAIL_ALREADY_REGISTERED);
+                });
 
         // 비밀번호 확인
         if (!registerDto.getPassword().equals(registerDto.getConfirmPassword())) {
-            throw new RestApiException(MemberErrorCode.WRONG_CONFIRM_PASSWORD);
+            throw new RestApiException(WRONG_CONFIRM_PASSWORD);
         }
 
         // 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(registerDto.getPassword());
 
         // 저장
-        member = new Member(registerDto.getEmail(), registerDto.getUserId(), registerDto.getName(), encodedPassword);
+        Member member = new Member(registerDto.getEmail(), registerDto.getUserId(), registerDto.getName(), encodedPassword);
         memberRepository.save(member);
 
         return new MemberResponseDto(member.getUserId(), member.getEmail(), member.getName(),

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
@@ -3,6 +3,7 @@ package com.example.InstagramCloneCoding.domain.member.application;
 import com.example.InstagramCloneCoding.domain.member.dao.MemberRepository;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.member.dto.MemberRegisterDto;
+import com.example.InstagramCloneCoding.domain.member.dto.MemberResponseDto;
 import com.example.InstagramCloneCoding.domain.member.error.MemberErrorCode;
 import com.example.InstagramCloneCoding.global.error.RestApiException;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,7 @@ public class MemberService {
 
     private final PasswordEncoder passwordEncoder;
 
-    public Member register(MemberRegisterDto registerDto) {
+    public MemberResponseDto register(MemberRegisterDto registerDto) {
         // 아이디 중복 확인
         Member member = memberRepository.findById(registerDto.getUserId()).orElse(null);
         if (member != null) {
@@ -45,7 +46,10 @@ public class MemberService {
 
         // 저장
         member = new Member(registerDto.getEmail(), registerDto.getUserId(), registerDto.getName(), encodedPassword);
-        return memberRepository.save(member);
+        memberRepository.save(member);
+
+        return new MemberResponseDto(member.getUserId(), member.getEmail(), member.getName(),
+                member.getProfileImage(), member.getIntroduction());
     }
 
     public void changeProfileImage(String userId, String imagePath) {

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
@@ -39,7 +39,7 @@ public class Member {
     @Column(name = "email_verified", nullable = false)
     private boolean emailVerified;
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", orphanRemoval = true)
     private List<Post> posts = new ArrayList<>();
 
     @OneToMany(mappedBy = "follower")

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
@@ -19,25 +19,25 @@ public class Member {
 
     @Id
     @Column(name = "user_id")
-    String userId;
+    private String userId;
 
     @Column(name = "email", nullable = false)
-    String email;
+    private String email;
 
     @Column(name = "password", nullable = false)
-    String password;
+    private String password;
 
     @Column(name = "profile_image")
-    String profileImage;
+    private String profileImage;
 
     @Column(name = "name", nullable = false)
-    String name;
+    private String name;
 
     @Column(name = "introduction")
-    String introduction;
+    private String introduction;
 
     @Column(name = "email_verified", nullable = false)
-    boolean emailVerified;
+    private boolean emailVerified;
 
     @OneToMany(mappedBy = "member")
     private List<Post> posts = new ArrayList<>();

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/dto/MemberResponseDto.java
@@ -1,0 +1,21 @@
+package com.example.InstagramCloneCoding.domain.member.dto;
+
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+@AllArgsConstructor
+public class MemberResponseDto {
+
+    private String userId;
+
+    private String email;
+
+    private String name;
+
+    private String profileImage;
+
+    private String introduction;
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.transaction.Transactional;
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -39,5 +40,25 @@ public class PostApiController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(postResponseDto);
+    }
+
+    @GetMapping(value = "readAll")
+    public ResponseEntity<List<PostResponseDto>> readAll(@Parameter(hidden = true) @LoggedInUser Member member) {
+        List<PostResponseDto> postResponseDtos = new ArrayList<>();
+
+        member.getPosts().forEach(post -> {
+            List<String> postImages = new ArrayList<>();
+            post.getPostImages().forEach(postImage -> {
+                postImages.add(postImage.getPostImageId());
+            });
+
+            PostResponseDto postResponseDto = new PostResponseDto(post.getPostId(), post.getContent(),
+                    post.getCreatedAt(), postImages);
+
+            postResponseDtos.add(postResponseDto);
+        });
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(postResponseDtos);
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
@@ -6,7 +6,6 @@ import com.example.InstagramCloneCoding.domain.post.application.PostService;
 import com.example.InstagramCloneCoding.domain.post.domain.Post;
 import com.example.InstagramCloneCoding.domain.post.dto.PostResponseDto;
 import com.example.InstagramCloneCoding.global.common.annotation.LoggedInUser;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -36,9 +35,9 @@ public class PostApiController {
         List<String> fileNameList = awsS3Service.uploadFile(images);
 
         // 데이터베이스에 저장
-        Post post = postService.uploadPost(member, content, fileNameList);
+        PostResponseDto postResponseDto = postService.uploadPost(member, content, fileNameList);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(new PostResponseDto(post.getPostId(), post.getContent(), post.getCreatedAt(), fileNameList));
+                .body(postResponseDto);
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
@@ -3,7 +3,6 @@ package com.example.InstagramCloneCoding.domain.post.api;
 import com.example.InstagramCloneCoding.domain.member.application.AwsS3Service;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.post.application.PostService;
-import com.example.InstagramCloneCoding.domain.post.domain.Post;
 import com.example.InstagramCloneCoding.domain.post.dto.PostResponseDto;
 import com.example.InstagramCloneCoding.global.common.annotation.LoggedInUser;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -46,17 +45,9 @@ public class PostApiController {
     public ResponseEntity<List<PostResponseDto>> readAll(@Parameter(hidden = true) @LoggedInUser Member member) {
         List<PostResponseDto> postResponseDtos = new ArrayList<>();
 
-        member.getPosts().forEach(post -> {
-            List<String> postImages = new ArrayList<>();
-            post.getPostImages().forEach(postImage -> {
-                postImages.add(postImage.getPostImageId());
-            });
-
-            PostResponseDto postResponseDto = new PostResponseDto(post.getPostId(), post.getContent(),
-                    post.getCreatedAt(), postImages);
-
-            postResponseDtos.add(postResponseDto);
-        });
+        member.getPosts().forEach(post ->
+            postResponseDtos.add(post.postToResponseDto())
+        );
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(postResponseDtos);

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
@@ -15,13 +15,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 @RestController
-@RequestMapping("post/")
 @RequiredArgsConstructor
 public class PostApiController {
 
     private final PostService postService;
 
-    @PostMapping(value = "write", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/{member_id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<PostResponseDto> write(@Parameter(hidden = true) @LoggedInUser Member member,
                                 @RequestPart("images") List<MultipartFile> images,
                                 @RequestPart(value = "content", required = false) String content) {
@@ -32,7 +31,7 @@ public class PostApiController {
                 .body(postResponseDto);
     }
 
-    @GetMapping(value = "readAll/{member_id}")
+    @GetMapping(value = "/{member_id}")
     public ResponseEntity<List<PostResponseDto>> readAll(@Parameter(hidden = true) @LoggedInUser Member member,
                                                          @PathVariable("member_id") String memberId) {
         List<PostResponseDto> postResponseDtos = postService.findAll(memberId);
@@ -41,7 +40,7 @@ public class PostApiController {
                 .body(postResponseDtos);
     }
 
-    @GetMapping(value = "read/{post_id}")
+    @GetMapping(value = "p/{post_id}")
     public ResponseEntity<PostResponseDto> read(@Parameter(hidden = true) @LoggedInUser Member member,
                                                 @PathVariable("post_id") int postId) {
         PostResponseDto postResponseDto = postService.findByPostId(postId);
@@ -50,7 +49,7 @@ public class PostApiController {
                 .body(postResponseDto);
     }
 
-    @DeleteMapping(value = "/{post_id}")
+    @DeleteMapping(value = "p/{post_id}")
     public ResponseEntity delete(@Parameter(hidden = true) @LoggedInUser Member member,
                                  @PathVariable("post_id") int postId) {
         postService.deletePost(member, postId);

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
@@ -4,7 +4,9 @@ import com.example.InstagramCloneCoding.domain.member.application.AwsS3Service;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.post.application.PostService;
 import com.example.InstagramCloneCoding.domain.post.domain.Post;
+import com.example.InstagramCloneCoding.domain.post.dto.PostResponseDto;
 import com.example.InstagramCloneCoding.global.common.annotation.LoggedInUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -27,9 +29,9 @@ public class PostApiController {
     private final AwsS3Service awsS3Service;
 
     @PostMapping(value = "write", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<List<String>> write(@Parameter(hidden = true) @LoggedInUser Member member,
-                                  @RequestPart("images") List<MultipartFile> images,
-                                  @RequestPart(value = "content", required = false) String content) {
+    public ResponseEntity<PostResponseDto> write(@Parameter(hidden = true) @LoggedInUser Member member,
+                                @RequestPart("images") List<MultipartFile> images,
+                                @RequestPart(value = "content", required = false) String content) {
         // s3 bucket에 이미지 업로드
         List<String> fileNameList = awsS3Service.uploadFile(images);
 
@@ -37,6 +39,6 @@ public class PostApiController {
         Post post = postService.uploadPost(member, content, fileNameList);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(fileNameList);
+                .body(new PostResponseDto(post.getPostId(), post.getContent(), post.getCreatedAt(), fileNameList));
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
@@ -42,7 +42,7 @@ public class PostApiController {
                 .body(postResponseDto);
     }
 
-    @GetMapping(value = "readAll")
+    @GetMapping(value = "read")
     public ResponseEntity<List<PostResponseDto>> readAll(@Parameter(hidden = true) @LoggedInUser Member member) {
         List<PostResponseDto> postResponseDtos = new ArrayList<>();
 
@@ -60,5 +60,14 @@ public class PostApiController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(postResponseDtos);
+    }
+
+    @GetMapping(value = "read/{post_id}")
+    public ResponseEntity<PostResponseDto> read(@Parameter(hidden = true) @LoggedInUser Member member,
+                                                @PathVariable("post_id") int post_id) {
+        PostResponseDto postResponseDto = postService.findByPostId(post_id);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(postResponseDto);
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/api/PostApiController.java
@@ -21,7 +21,7 @@ public class PostApiController {
 
     private final PostService postService;
 
-    @PostMapping(value = "/", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "write", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<PostResponseDto> write(@Parameter(hidden = true) @LoggedInUser Member member,
                                 @RequestPart("images") List<MultipartFile> images,
                                 @RequestPart(value = "content", required = false) String content) {
@@ -32,15 +32,16 @@ public class PostApiController {
                 .body(postResponseDto);
     }
 
-    @GetMapping(value = "/")
-    public ResponseEntity<List<PostResponseDto>> readAll(@Parameter(hidden = true) @LoggedInUser Member member) {
-        List<PostResponseDto> postResponseDtos = postService.findAll(member);
+    @GetMapping(value = "readAll/{member_id}")
+    public ResponseEntity<List<PostResponseDto>> readAll(@Parameter(hidden = true) @LoggedInUser Member member,
+                                                         @PathVariable("member_id") String memberId) {
+        List<PostResponseDto> postResponseDtos = postService.findAll(memberId);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(postResponseDtos);
     }
 
-    @GetMapping(value = "/{post_id}")
+    @GetMapping(value = "read/{post_id}")
     public ResponseEntity<PostResponseDto> read(@Parameter(hidden = true) @LoggedInUser Member member,
                                                 @PathVariable("post_id") int postId) {
         PostResponseDto postResponseDto = postService.findByPostId(postId);

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/application/PostService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/application/PostService.java
@@ -6,11 +6,15 @@ import com.example.InstagramCloneCoding.domain.post.dao.PostRepository;
 import com.example.InstagramCloneCoding.domain.post.domain.Post;
 import com.example.InstagramCloneCoding.domain.post.domain.PostImage;
 import com.example.InstagramCloneCoding.domain.post.dto.PostResponseDto;
+import com.example.InstagramCloneCoding.global.error.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.ArrayList;
 import java.util.List;
+
+import static com.example.InstagramCloneCoding.domain.post.error.PostErrorCode.POST_NOT_FOUND;
 
 @Service
 @Transactional
@@ -33,5 +37,17 @@ public class PostService {
         });
 
         return new PostResponseDto(post.getPostId(), post.getContent(), post.getCreatedAt(), fileNameList);
+    }
+
+    public PostResponseDto findByPostId(int post_id) {
+        Post post = postRepository.findById(post_id)
+                .orElseThrow(() -> new RestApiException(POST_NOT_FOUND));
+
+        List<String> postImages = new ArrayList<>();
+        post.getPostImages().forEach(postImage -> {
+            postImages.add(postImage.getPostImageId());
+        });
+
+        return new PostResponseDto(post.getPostId(), post.getContent(), post.getCreatedAt(), postImages);
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/application/PostService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/application/PostService.java
@@ -1,6 +1,7 @@
 package com.example.InstagramCloneCoding.domain.post.application;
 
 import com.example.InstagramCloneCoding.domain.member.application.AwsS3Service;
+import com.example.InstagramCloneCoding.domain.member.dao.MemberRepository;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.post.dao.PostImageRepository;
 import com.example.InstagramCloneCoding.domain.post.dao.PostRepository;
@@ -16,6 +17,7 @@ import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.example.InstagramCloneCoding.domain.member.error.MemberErrorCode.MEMBER_NOT_FOUND;
 import static com.example.InstagramCloneCoding.domain.post.error.PostErrorCode.POST_NOT_FOUND;
 import static com.example.InstagramCloneCoding.global.error.CommonErrorCode.FORBIDDEN;
 
@@ -27,6 +29,8 @@ public class PostService {
     private final PostRepository postRepository;
 
     private final PostImageRepository postImageRepository;
+
+    private final MemberRepository memberRepository;
 
     private final AwsS3Service awsS3Service;
 
@@ -54,7 +58,10 @@ public class PostService {
         return post.postToResponseDto();
     }
 
-    public List<PostResponseDto> findAll(Member member) {
+    public List<PostResponseDto> findAll(String memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RestApiException(MEMBER_NOT_FOUND));
+
         List<PostResponseDto> postResponseDtos = new ArrayList<>();
 
         member.getPosts().forEach(post ->

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/application/PostService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/application/PostService.java
@@ -1,5 +1,6 @@
 package com.example.InstagramCloneCoding.domain.post.application;
 
+import com.example.InstagramCloneCoding.domain.member.application.AwsS3Service;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.post.dao.PostImageRepository;
 import com.example.InstagramCloneCoding.domain.post.dao.PostRepository;
@@ -9,11 +10,14 @@ import com.example.InstagramCloneCoding.domain.post.dto.PostResponseDto;
 import com.example.InstagramCloneCoding.global.error.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.transaction.Transactional;
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.example.InstagramCloneCoding.domain.post.error.PostErrorCode.POST_NOT_FOUND;
+import static com.example.InstagramCloneCoding.global.error.CommonErrorCode.FORBIDDEN;
 
 @Service
 @Transactional
@@ -24,7 +28,12 @@ public class PostService {
 
     private final PostImageRepository postImageRepository;
 
-    public PostResponseDto uploadPost(Member member, String content, List<String> fileNameList) {
+    private final AwsS3Service awsS3Service;
+
+    public PostResponseDto uploadPost(Member member, String content, List<MultipartFile> images) {
+        // s3 bucket에 이미지 업로드
+        List<String> fileNameList = awsS3Service.uploadFile(images);
+
         // post 저장
         Post post = new Post(member, content);
         postRepository.save(post);
@@ -38,10 +47,36 @@ public class PostService {
         return post.postToResponseDto();
     }
 
-    public PostResponseDto findByPostId(int post_id) {
-        Post post = postRepository.findById(post_id)
+    public PostResponseDto findByPostId(int postId) {
+        Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new RestApiException(POST_NOT_FOUND));
 
         return post.postToResponseDto();
+    }
+
+    public List<PostResponseDto> findAll(Member member) {
+        List<PostResponseDto> postResponseDtos = new ArrayList<>();
+
+        member.getPosts().forEach(post ->
+                postResponseDtos.add(post.postToResponseDto())
+        );
+
+        return postResponseDtos;
+    }
+
+    public void deletePost(Member member, int postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new RestApiException(POST_NOT_FOUND));
+
+        // 포스트 작성자인지 확인
+        if (!post.getMember().equals(member))
+            throw new RestApiException(FORBIDDEN);
+
+        // s3 버킷에서 이미지 삭제
+        post.getPostImages().forEach(postImage ->
+            awsS3Service.deleteFile(postImage.getPostImageId().substring(59)));
+
+        // 포스트 삭제
+        postRepository.deleteById(postId);
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/application/PostService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/application/PostService.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.example.InstagramCloneCoding.domain.post.error.PostErrorCode.POST_NOT_FOUND;
@@ -36,18 +35,13 @@ public class PostService {
             postImageRepository.save(postImage);
         });
 
-        return new PostResponseDto(post.getPostId(), post.getContent(), post.getCreatedAt(), fileNameList);
+        return post.postToResponseDto();
     }
 
     public PostResponseDto findByPostId(int post_id) {
         Post post = postRepository.findById(post_id)
                 .orElseThrow(() -> new RestApiException(POST_NOT_FOUND));
 
-        List<String> postImages = new ArrayList<>();
-        post.getPostImages().forEach(postImage -> {
-            postImages.add(postImage.getPostImageId());
-        });
-
-        return new PostResponseDto(post.getPostId(), post.getContent(), post.getCreatedAt(), postImages);
+        return post.postToResponseDto();
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/application/PostService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/application/PostService.java
@@ -5,6 +5,7 @@ import com.example.InstagramCloneCoding.domain.post.dao.PostImageRepository;
 import com.example.InstagramCloneCoding.domain.post.dao.PostRepository;
 import com.example.InstagramCloneCoding.domain.post.domain.Post;
 import com.example.InstagramCloneCoding.domain.post.domain.PostImage;
+import com.example.InstagramCloneCoding.domain.post.dto.PostResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,7 +21,7 @@ public class PostService {
 
     private final PostImageRepository postImageRepository;
 
-    public Post uploadPost(Member member, String content, List<String> fileNameList) {
+    public PostResponseDto uploadPost(Member member, String content, List<String> fileNameList) {
         // post 저장
         Post post = new Post(member, content);
         postRepository.save(post);
@@ -31,6 +32,6 @@ public class PostService {
             postImageRepository.save(postImage);
         });
 
-        return post;
+        return new PostResponseDto(post.getPostId(), post.getContent(), post.getCreatedAt(), fileNameList);
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/domain/Post.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/domain/Post.java
@@ -1,6 +1,7 @@
 package com.example.InstagramCloneCoding.domain.post.domain;
 
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.domain.post.dto.PostResponseDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -41,5 +42,14 @@ public class Post {
     public Post(Member member, String content) {
         this.member = member;
         this.content = content;
+    }
+
+    public PostResponseDto postToResponseDto() {
+       return PostResponseDto.builder()
+                .postId(postId)
+                .content(content)
+                .createdAt(createdAt)
+                .postImages(postImages)
+                .build();
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/domain/Post.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/domain/Post.java
@@ -36,7 +36,7 @@ public class Post {
     @JoinColumn(name = "user_id", nullable = false)
     private Member member;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", orphanRemoval = true)
     private List<PostImage> postImages = new ArrayList<>();
 
     public Post(Member member, String content) {

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/domain/PostImage.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/domain/PostImage.java
@@ -8,8 +8,7 @@ import javax.persistence.*;
 
 @Entity
 @Table(name = "post_image")
-@Getter
-@Setter
+@Getter @Setter
 @NoArgsConstructor
 public class PostImage {
 

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/dto/PostResponseDto.java
@@ -1,6 +1,6 @@
 package com.example.InstagramCloneCoding.domain.post.dto;
 
-import com.example.InstagramCloneCoding.domain.post.domain.PostImage;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,6 +16,7 @@ public class PostResponseDto {
 
     private String content;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyyMMddHHmmss")
     private LocalDateTime createdAt;
 
     private List<String> postImages;

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/dto/PostResponseDto.java
@@ -1,15 +1,16 @@
 package com.example.InstagramCloneCoding.domain.post.dto;
 
+import com.example.InstagramCloneCoding.domain.post.domain.PostImage;
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter @Setter
-@AllArgsConstructor
 public class PostResponseDto {
 
     private int postId;
@@ -20,4 +21,18 @@ public class PostResponseDto {
     private LocalDateTime createdAt;
 
     private List<String> postImages;
+
+    @Builder
+    public PostResponseDto(int postId, String content, LocalDateTime createdAt, List<PostImage> postImages) {
+        this.postId = postId;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.postImages = getPostImagesName(postImages);
+    }
+
+    private List<String> getPostImagesName(List<PostImage> postImages) {
+        return postImages.stream()
+                .map(PostImage::getPostImageId)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/dto/PostResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.InstagramCloneCoding.domain.post.dto;
+
+import com.example.InstagramCloneCoding.domain.post.domain.PostImage;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter @Setter
+@AllArgsConstructor
+public class PostResponseDto {
+
+    private int postId;
+
+    private String content;
+
+    private LocalDateTime createdAt;
+
+    private List<String> postImages;
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/error/PostErrorCode.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/error/PostErrorCode.java
@@ -1,0 +1,17 @@
+package com.example.InstagramCloneCoding.domain.post.error;
+
+import com.example.InstagramCloneCoding.global.error.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum PostErrorCode implements ErrorCode {
+
+    POST_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "post not found"),
+    ;
+
+    private HttpStatus httpStatus;
+    private String message;
+}

--- a/src/main/java/com/example/InstagramCloneCoding/global/error/CommonErrorCode.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/error/CommonErrorCode.java
@@ -11,6 +11,7 @@ public enum CommonErrorCode implements ErrorCode {
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included"),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not exists"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "forbidden"),
     ;
 
     private HttpStatus httpStatus;


### PR DESCRIPTION
## 개요
포스트 읽기, 삭제 기능 구현

## 작업사항
- /{member_id}로 get 요청 보내면 해당 유저가 작성한 전체 포스트를 PostResponseDto에 담아서 반환. post 요청을 보내면 글 작성.
- /p/{post_id}로 get 요청 보내면 포스트 아이디에 해당하는 포스트 찾아서 PostResonseDto에 담아서 반환. delete 요청 보내면 해당 포스트 작성자가 맞는지 확인한 다음 포스트 삭제. 이때 aws s3 버킷에서도 이미지 삭제됨.
- Member 클래스의 posts와 Post 클래스의 postImages @OneToMany 어노테이션 속성 값으로 orphanRemoval = true 추가함. 멤버나 포스트 삭제할 때 그와 관련된 포스트와 이미지를 함께 삭제해주는 역할 (좀 더 정확히는 연관관계가 끊길 때 자동으로 삭제해준다고 함 참고해볼만한 글: https://tecoble.techcourse.co.kr/post/2021-08-15-jpa-cascadetype-remove-vs-orphanremoval-true/ )
- 추후에 좋아요와 코멘트 구현 후 postResponseDto 수정 필요

## 변경로직
- Post 클래스에 postToResonseDto() 메소드를 만들어서 반복되는 코드 대체함.