### PR TITLE
Follow, Home 기능 Refactor

### DIFF
--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/api/FollowApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/api/FollowApiController.java
@@ -4,6 +4,7 @@ import com.example.InstagramCloneCoding.domain.follow.application.FollowFindServ
 import com.example.InstagramCloneCoding.domain.follow.application.FollowService;
 import com.example.InstagramCloneCoding.domain.follow.dto.FollowDto;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.domain.member.dto.MemberResponseDto;
 import com.example.InstagramCloneCoding.global.common.annotation.LoggedInUser;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
@@ -38,24 +39,24 @@ public class FollowApiController {
     }
 
     @GetMapping("/getfollowers")
-    public ResponseEntity<List<String>> followers(@Parameter(hidden = true) @LoggedInUser Member member) {
-        List<String> followersId = followFindService.getFollowersId(member);
+    public ResponseEntity<List<MemberResponseDto>> followers(@Parameter(hidden = true) @LoggedInUser Member member) {
+        List<MemberResponseDto> followersId = followFindService.getFollowersId(member);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(followersId);
     }
 
     @GetMapping("/getfollowings")
-    public ResponseEntity<List<String>> followings(@Parameter(hidden = true) @LoggedInUser Member member) {
-        List<String> followingsId = followFindService.getFollowingsId(member);
+    public ResponseEntity<List<MemberResponseDto>> followings(@Parameter(hidden = true) @LoggedInUser Member member) {
+        List<MemberResponseDto> followingsId = followFindService.getFollowingsId(member);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(followingsId);
     }
 
     @GetMapping("/getfollowbacks")
-    public ResponseEntity<List<String>> followBack(@Parameter(hidden = true) @LoggedInUser Member member) {
-        List<String> friendsId = followFindService.getFollowingBacksId(member);
+    public ResponseEntity<List<MemberResponseDto>> followBack(@Parameter(hidden = true) @LoggedInUser Member member) {
+        List<MemberResponseDto> friendsId = followFindService.getFollowingBacksId(member);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(friendsId);

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowFindService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowFindService.java
@@ -2,6 +2,7 @@ package com.example.InstagramCloneCoding.domain.follow.application;
 
 import com.example.InstagramCloneCoding.domain.member.application.MemberFindService;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.domain.member.dto.MemberResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,27 +17,27 @@ public class FollowFindService {
 
     private final MemberFindService memberFindService;
 
-    public List<String> getFollowersId(Member member) {
+    public List<MemberResponseDto> getFollowersId(Member member) {
         List<Member> followers = memberFindService.findFollowers(member);
 
         return getIds(followers);
     }
 
-    public List<String> getFollowingsId(Member member) {
+    public List<MemberResponseDto> getFollowingsId(Member member) {
         List<Member> followings = memberFindService.findFollowings(member);
 
         return getIds(followings);
     }
 
-    public List<String> getFollowingBacksId(Member member) {
+    public List<MemberResponseDto> getFollowingBacksId(Member member) {
         List<Member> friends = memberFindService.findFollowBacks(member);
 
         return getIds(friends);
     }
 
-    private List<String> getIds(List<Member> friends) {
-        return friends.stream()
-                .map(Member::getUserId)
+    private List<MemberResponseDto> getIds(List<Member> members) {
+        return members.stream()
+                .map(Member::MemberToResponseDto)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowFindService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowFindService.java
@@ -37,7 +37,7 @@ public class FollowFindService {
 
     private List<MemberResponseDto> getIds(List<Member> members) {
         return members.stream()
-                .map(Member::MemberToResponseDto)
+                .map(Member::memberToResponseDto)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/home/application/HomeService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/home/application/HomeService.java
@@ -29,13 +29,7 @@ public class HomeService {
         member.setLastHomeAccessTime(LocalDateTime.now());
 
         return posts.stream()
-                .map(post -> PostResponseDto.builder()
-                        .postId(post.getPostId())
-                        .authorId(post.getMember().getUserId())
-                        .content(post.getContent())
-                        .createdAt(post.getCreatedAt())
-                        .postImages(post.getPostImages())
-                        .build())
+                .map(Post::postToResponseDto)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
@@ -59,7 +59,7 @@ public class MemberService {
         // 이메일 인증 메일 보내기
         emailConfirmService.createEmailConfirmationToken(member.getUserId(), member.getEmail());
 
-        return member.MemberToResponseDto();
+        return member.memberToResponseDto();
     }
 
     public void changeProfileImage(String userId, String imagePath) {

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
@@ -59,8 +59,7 @@ public class MemberService {
         // 이메일 인증 메일 보내기
         emailConfirmService.createEmailConfirmationToken(member.getUserId(), member.getEmail());
 
-        return new MemberResponseDto(member.getUserId(), member.getEmail(), member.getName(),
-                member.getProfileImage(), member.getIntroduction());
+        return member.MemberToResponseDto();
     }
 
     public void changeProfileImage(String userId, String imagePath) {

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
@@ -64,7 +64,7 @@ public class Member {
         this.lastHomeAccessTime = lastHomeAccessTime;
     }
 
-    public MemberResponseDto MemberToResponseDto(){
+    public MemberResponseDto memberToResponseDto(){
         return new MemberResponseDto(userId, email, name, profileImage, introduction);
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
@@ -48,10 +48,10 @@ public class Member {
     @OneToMany(mappedBy = "member", orphanRemoval = true)
     private List<Post> posts = new ArrayList<>();
 
-    @OneToMany(mappedBy = "follower")
+    @OneToMany(mappedBy = "follower", orphanRemoval = true)
     private List<Follow> followings = new ArrayList<>();
 
-    @OneToMany(mappedBy = "following")
+    @OneToMany(mappedBy = "following", orphanRemoval = true)
     private List<Follow> followers = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
@@ -1,6 +1,7 @@
 package com.example.InstagramCloneCoding.domain.member.domain;
 
 import com.example.InstagramCloneCoding.domain.follow.domain.Follow;
+import com.example.InstagramCloneCoding.domain.member.dto.MemberResponseDto;
 import com.example.InstagramCloneCoding.domain.post.domain.Post;
 import lombok.Builder;
 import lombok.Getter;
@@ -61,5 +62,9 @@ public class Member {
         this.password = password;
         this.emailVerified = false;
         this.lastHomeAccessTime = lastHomeAccessTime;
+    }
+
+    public MemberResponseDto MemberToResponseDto(){
+        return new MemberResponseDto(userId, email, name, profileImage, introduction);
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/dto/MemberResponseDto.java
@@ -1,11 +1,11 @@
 package com.example.InstagramCloneCoding.domain.member.dto;
 
-import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter @Setter
+@Getter
+@Setter
 @AllArgsConstructor
 public class MemberResponseDto {
 


### PR DESCRIPTION
## 개요
- follow, home api에서 돌려주는 json 값 변경
- Member 삭제 시 follower, following 관계도 자동으로 삭제되게 수정

## 작업사항
- Member 엔티티에 MemberResponseDto로 변환해주는 함수 추가
- Followers, Followings 리스트 리턴 시 유저ID만 리턴했는데, MemberResponseDto로 기타 정보(이름, 이메일, 설명, 프로필 사진)도 추가하여 함께 리턴시킴
- HomeService에서 PostResponse로 변환 시 new 말고 Post 내부의 변환 함수 사용

## 변경로직
- MemberService의 register()함수에서 마지막에 new MemberResponseDto(~~)를 member.memberToResponseDto()로 변경
