### PR TITLE
회원가입 시 이메일 인증 방식 변경, 프로필 변경 구현

### DIFF
--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberAccountsApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberAccountsApiController.java
@@ -1,16 +1,12 @@
 package com.example.InstagramCloneCoding.domain.member.api;
 
-import com.example.InstagramCloneCoding.domain.member.application.EmailConfirmService;
 import com.example.InstagramCloneCoding.domain.member.application.MemberService;
-import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.member.dto.MemberRegisterDto;
 import com.example.InstagramCloneCoding.domain.member.dto.MemberResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import javax.transaction.Transactional;
 
 @RestController
 @RequestMapping("accounts/")
@@ -19,23 +15,21 @@ public class MemberAccountsApiController {
 
     private final MemberService memberService;
 
-    private final EmailConfirmService emailConfirmService;
+    @PostMapping("signup")
+    public ResponseEntity<String> check(@RequestBody MemberRegisterDto registerDto) {
+        // 중복 가입인지 확인하고 인증 메일 보내기
+        String code = memberService.checkAndSendMail(registerDto);
 
-    @PostMapping("emailsignup")
-    public ResponseEntity<MemberResponseDto> register(@RequestBody MemberRegisterDto registerDto) {
-        // 회원가입 (member 테이블에 추가 & 인증메일 보내기)
-        MemberResponseDto memberResponseDto = memberService.register(registerDto);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(code);
+    }
+
+    @PostMapping("save")
+    public ResponseEntity<MemberResponseDto> save(@RequestBody MemberRegisterDto registerDto) {
+        // member 테이블에 저장
+        MemberResponseDto memberResponseDto = memberService.saveMember(registerDto);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(memberResponseDto);
-    }
-
-    @GetMapping("confirm-email")
-    public ResponseEntity<Member> confirmEmail(@RequestParam String token) {
-        // 이메일 인증 완료하고 member 테이블의 email_verified 컬럼 true로 바꿔주기
-        emailConfirmService.confirmEmail(token);
-
-        return ResponseEntity.status(HttpStatus.OK)
-                .build();
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/AwsS3Service.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/AwsS3Service.java
@@ -56,6 +56,6 @@ public class AwsS3Service {
     }
 
     public void deleteFile(String fileName) {
-        amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
+        amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName.substring(59)));
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailConfirmService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/EmailConfirmService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.time.LocalDateTime;
+import java.util.Random;
 
 import static com.example.InstagramCloneCoding.domain.member.error.MemberErrorCode.MEMBER_NOT_FOUND;
 import static com.example.InstagramCloneCoding.domain.member.error.MemberErrorCode.TOKEN_NOT_FOUND;
@@ -56,5 +57,24 @@ public class EmailConfirmService {
         memberRepository.save(member);
 
         return member;
+    }
+
+    public String createEmailAuthenticationCode(String receiverEmail) {
+        // 랜덤 인증 코드 생성
+        String code;
+        Random random = new Random();
+        StringBuffer codeBuffer = new StringBuffer();
+        for (int i = 0; i < 6; i++)
+            codeBuffer.append(random.nextInt(9));
+        code = codeBuffer.toString();
+
+        // 메일 보내기
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(receiverEmail);
+        message.setSubject("인스타그램(클론) 회원가입 이메일 인증");
+        message.setText("이메일 인증 코드는 " + code + " 입니다.");
+        emailSenderService.sendEmail(message);
+
+        return code;
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
@@ -2,15 +2,18 @@ package com.example.InstagramCloneCoding.domain.member.application;
 
 import com.example.InstagramCloneCoding.domain.member.dao.MemberRepository;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.domain.member.dto.MemberEditDto;
 import com.example.InstagramCloneCoding.domain.member.dto.MemberRegisterDto;
 import com.example.InstagramCloneCoding.domain.member.dto.MemberResponseDto;
 import com.example.InstagramCloneCoding.global.error.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.transaction.Transactional;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static com.example.InstagramCloneCoding.domain.member.error.MemberErrorCode.*;
 
@@ -25,24 +28,9 @@ public class MemberService {
 
     private final EmailConfirmService emailConfirmService;
 
-    public MemberResponseDto register(MemberRegisterDto registerDto) {
-        // 아이디 중복 확인
-        memberRepository.findById(registerDto.getUserId())
-                .ifPresent(member -> {
-                    throw new RestApiException(ID_ALREADY_EXISTS);
-                });
+    private final AwsS3Service awsS3Service;
 
-        // 이메일 중복 확인
-        memberRepository.findByEmail(registerDto.getEmail())
-                .ifPresent(member -> {
-                    throw new RestApiException(EMAIL_ALREADY_REGISTERED);
-                });
-
-//        // 비밀번호 확인
-//        if (!registerDto.getPassword().equals(registerDto.getConfirmPassword())) {
-//            throw new RestApiException(WRONG_CONFIRM_PASSWORD);
-//        }
-
+    public MemberResponseDto saveMember(MemberRegisterDto registerDto) {
         // 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(registerDto.getPassword());
 
@@ -56,20 +44,55 @@ public class MemberService {
                 .build();
         memberRepository.save(member);
 
-        // 이메일 인증 메일 보내기
-        emailConfirmService.createEmailConfirmationToken(member.getUserId(), member.getEmail());
-
         return member.memberToResponseDto();
     }
 
-    public void changeProfileImage(String userId, String imagePath) {
-        // 멤버 가져오기
-        Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new RestApiException(MEMBER_NOT_FOUND));
+    public String checkAndSendMail(MemberRegisterDto memberRegisterDto) {
+        // 아이디 중복 확인
+        memberRepository.findById(memberRegisterDto.getUserId())
+                .ifPresent(member -> {
+                    throw new RestApiException(ID_ALREADY_EXISTS);
+                });
+
+        // 이메일 중복 확인
+        memberRepository.findByEmail(memberRegisterDto.getEmail())
+                .ifPresent(member -> {
+                    throw new RestApiException(EMAIL_ALREADY_REGISTERED);
+                });
+
+        return emailConfirmService.createEmailAuthenticationCode(memberRegisterDto.getEmail());
+    }
+
+    public MemberResponseDto changeProfileImage(Member member, List<MultipartFile> multipartFile) {
+        // 기존 프로필 사진 s3 버킷에서 삭제
+        if (member.getProfileImage() != null)
+            awsS3Service.deleteFile(member.getProfileImage());
+
+        // s3 버킷에 이미지 저장
+        String imagePath = awsS3Service.uploadFile(multipartFile).get(0);
 
         // 프로필 이미지 경로 업데이트
         member.setProfileImage(imagePath);
         memberRepository.save(member);
+
+        return member.memberToResponseDto();
+    }
+
+    public MemberResponseDto changeProfile(Member member, MemberEditDto memberEditDto) {
+        // 이메일 변경되었는지 확인 -> 변경되었으면 인증용 메일 보내기
+        if (!member.getEmail().equals(memberEditDto.getEmail())) {
+            member.setEmailVerified(false);
+            member.setEmail(memberEditDto.getEmail());
+            emailConfirmService.createEmailConfirmationToken(member.getUserId(), member.getEmail());
+        }
+
+        // 이름과 소개글 변경
+        member.setName(memberEditDto.getName());
+        member.setIntroduction(memberEditDto.getIntroduction());
+
+        memberRepository.save(member);
+
+        return member.memberToResponseDto();
     }
 }
 

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
@@ -55,7 +55,7 @@ public class Member {
     private List<Follow> followers = new ArrayList<>();
 
     @Builder
-    public Member(String email, String userId, String name, String password, LocalDateTime lastHomeAccessTime) {
+    public Member(String email, String userId, String name, String password, LocalDateTime lastHomeAccessTime, String introduction) {
         this.email = email;
         this.userId = userId;
         this.name = name;

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
@@ -55,12 +55,12 @@ public class Member {
     private List<Follow> followers = new ArrayList<>();
 
     @Builder
-    public Member(String email, String userId, String name, String password, LocalDateTime lastHomeAccessTime, String introduction) {
+    public Member(String email, String userId, String name, String password, LocalDateTime lastHomeAccessTime) {
         this.email = email;
         this.userId = userId;
         this.name = name;
         this.password = password;
-        this.emailVerified = false;
+        this.emailVerified = true;
         this.lastHomeAccessTime = lastHomeAccessTime;
     }
 

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/dto/MemberEditDto.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/dto/MemberEditDto.java
@@ -1,0 +1,14 @@
+package com.example.InstagramCloneCoding.domain.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class MemberEditDto {
+
+    String email;
+
+    String name;
+
+    String introduction;
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/dto/MemberRegisterDto.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/dto/MemberRegisterDto.java
@@ -20,7 +20,4 @@ public class MemberRegisterDto {
 
     @NotBlank
     private String password;
-
-//    @NotBlank
-//    private String confirmPassword;
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/application/PostService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/application/PostService.java
@@ -81,7 +81,7 @@ public class PostService {
 
         // s3 버킷에서 이미지 삭제
         post.getPostImages().forEach(postImage ->
-            awsS3Service.deleteFile(postImage.getPostImageId().substring(59)));
+            awsS3Service.deleteFile(postImage.getPostImageId()));
 
         // 포스트 삭제
         postRepository.deleteById(postId);


### PR DESCRIPTION
## 개요
- 회원가입 시 이메일 인증 방식을 인증용 url에서 인증용 코드로 변경.
- 프로필 변경 구현

## 작업사항
- /accounts/signup으로 가입 요청을 보내면 중복 가입 확인을 한 후 인증용 코드를 사용자 메일과 클라이언트로 보냄.
- 사용자가 입력한 인증 코드가 일치하는지는 클라이언트에서 처리해야 함.
- 이메일 인증이 완료됐으면 다시 accounts/save로 요청을 보내면 사용자가 데이터베이스에 저장됨.
<br>

- /edit/profile로 요청을 보내면 사용자 프로필을 변경할 수 있음.
- 변경 가능한 항목은 email, name, introduction.
- 이메일은 변경할 시 email_verified 컬럼이 false로 바뀌며, 변경된 이메일로 인증용 메일이 발신됨. 해당 메일에 있는 링크를 클릭하여야 email_verified 컬럼이 true로 변경됨.

## 변경로직
- memberEditController에서 @Transactional 어노테이션 제거.
- 프로필 이미지 변경 시 이전 프로필 이미지는 s3 버킷에서 삭제되도록 수정.
