### PR TITLE
댓글 작성, 삭제 기능

### DIFF
--- a/src/main/java/com/example/InstagramCloneCoding/domain/comment/api/CommentController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/comment/api/CommentController.java
@@ -27,4 +27,12 @@ public class CommentController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(commentResponseDto);
     }
+
+    @DeleteMapping("{comment_id}")
+    public ResponseEntity delete(@Parameter(hidden = true) @LoggedInUser Member member,
+                                 @PathVariable("comment_id") int commentId) {
+        commentService.deleteComment(member, commentId);
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/comment/api/CommentController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/comment/api/CommentController.java
@@ -1,0 +1,30 @@
+package com.example.InstagramCloneCoding.domain.comment.api;
+
+import com.example.InstagramCloneCoding.domain.comment.application.CommentService;
+import com.example.InstagramCloneCoding.domain.comment.dto.CommentDto;
+import com.example.InstagramCloneCoding.domain.comment.dto.CommentResponseDto;
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.global.common.annotation.LoggedInUser;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("comment/")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("{post_id}")
+    public ResponseEntity<CommentResponseDto> write(@Parameter(hidden = true) @LoggedInUser Member member,
+                                @PathVariable("post_id") int postId,
+                                @RequestBody CommentDto commentDto) {
+        CommentResponseDto commentResponseDto = commentService.writeComment(member, postId, commentDto);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(commentResponseDto);
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/comment/application/CommentService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/comment/application/CommentService.java
@@ -1,0 +1,72 @@
+package com.example.InstagramCloneCoding.domain.comment.application;
+
+import com.example.InstagramCloneCoding.domain.comment.dao.CommentRepository;
+import com.example.InstagramCloneCoding.domain.comment.domain.Comment;
+import com.example.InstagramCloneCoding.domain.comment.dto.CommentDto;
+import com.example.InstagramCloneCoding.domain.comment.dto.CommentResponseDto;
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.domain.post.dao.PostRepository;
+import com.example.InstagramCloneCoding.domain.post.domain.Post;
+import com.example.InstagramCloneCoding.global.error.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+import java.util.List;
+
+import static com.example.InstagramCloneCoding.domain.comment.error.CommentErrorCode.COMMENT_NOT_FOUND;
+import static com.example.InstagramCloneCoding.domain.comment.error.CommentErrorCode.UNAVAILABLE_COMMENT_REQUEST;
+import static com.example.InstagramCloneCoding.domain.post.error.PostErrorCode.POST_NOT_FOUND;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final PostRepository postRepository;
+
+    private final CommentRepository commentRepository;
+
+    public CommentResponseDto writeComment(Member member, int postId, CommentDto commentDto) {
+        int ref, refStep;
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new RestApiException(POST_NOT_FOUND));
+
+        // 대댓글인 경우 (CommentDto의 commentId가 null이 아닌 경우)
+        if (commentDto.getCommentId() != null) {
+            Comment comment = commentRepository.findById(commentDto.getCommentId())
+                    .orElseThrow(() -> new RestApiException(COMMENT_NOT_FOUND));
+            if (comment.getPost().getPostId() != postId)
+                throw new RestApiException(UNAVAILABLE_COMMENT_REQUEST);
+
+            ref = comment.getRef();
+            refStep = commentRepository.findByPostAndRef(post, comment.getRef()).size();
+        }
+        // 대댓글이 아닌 경우 (CommentDto의 commentId가 null인 경우)
+        else {
+            List<Comment> comments = post.getComments();
+
+            // 첫 댓글인 경우
+            if (comments.size() == 0) {
+                ref = 0;
+                refStep = 0;
+            }
+            else {
+                ref = comments.get(comments.size() - 1).getRef() + 1;
+                refStep = 0;
+            }
+        }
+
+        Comment comment = Comment.builder()
+                .content(commentDto.getComment())
+                .member(member)
+                .post(post)
+                .ref(ref)
+                .refStep(refStep)
+                .build();
+        commentRepository.save(comment);
+
+        return comment.commentToResponseDto();
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/comment/dao/CommentRepository.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/comment/dao/CommentRepository.java
@@ -11,4 +11,6 @@ import java.util.List;
 public interface CommentRepository extends JpaRepository<Comment, Integer> {
 
     List<Comment> findByPostAndRef(Post post, int ref);
+
+    List<Comment> findByRef(int ref);
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/comment/dao/CommentRepository.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/comment/dao/CommentRepository.java
@@ -1,0 +1,14 @@
+package com.example.InstagramCloneCoding.domain.comment.dao;
+
+import com.example.InstagramCloneCoding.domain.comment.domain.Comment;
+import com.example.InstagramCloneCoding.domain.post.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Integer> {
+
+    List<Comment> findByPostAndRef(Post post, int ref);
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/comment/domain/Comment.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/comment/domain/Comment.java
@@ -1,0 +1,61 @@
+package com.example.InstagramCloneCoding.domain.comment.domain;
+
+import com.example.InstagramCloneCoding.domain.comment.dto.CommentResponseDto;
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.domain.post.domain.Post;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "comment")
+@Getter @Setter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id", nullable = false)
+    private int commentId;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Column(name = "ref")
+    private int ref;
+
+    @Column(name = "ref_step")
+    private int refStep;
+
+    @Builder
+    public Comment(String content, Member member, Post post, int ref, int refStep) {
+        this.content = content;
+        this.member = member;
+        this.post = post;
+        this.ref = ref;
+        this.refStep = refStep;
+    }
+
+    public CommentResponseDto commentToResponseDto() {
+        return new CommentResponseDto(commentId, post.getPostId(), member.getUserId(), content, createdAt, ref);
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/comment/dto/CommentDto.java
@@ -1,0 +1,15 @@
+package com.example.InstagramCloneCoding.domain.comment.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter @Setter
+public class CommentDto {
+
+    private Integer commentId;
+
+    @NotNull
+    private String comment;
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/comment/dto/CommentResponseDto.java
@@ -1,0 +1,35 @@
+package com.example.InstagramCloneCoding.domain.comment.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter @Setter
+public class CommentResponseDto {
+
+    private int commentId;
+
+    private int postId;
+
+    private String userId;
+
+    private String content;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyyMMddHHmmss")
+    private LocalDateTime createdAt;
+
+    int ref;
+
+    @Builder
+    public CommentResponseDto(int commentId, int postId, String userId, String content, LocalDateTime createdAt, int ref) {
+        this.commentId = commentId;
+        this.postId = postId;
+        this.userId = userId;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.ref = ref;
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/comment/error/CommentErrorCode.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/comment/error/CommentErrorCode.java
@@ -1,0 +1,18 @@
+package com.example.InstagramCloneCoding.domain.comment.error;
+
+import com.example.InstagramCloneCoding.global.error.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CommentErrorCode implements ErrorCode {
+
+    COMMENT_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "comment not found"),
+    UNAVAILABLE_COMMENT_REQUEST(HttpStatus.BAD_REQUEST, "unavailable comment request"),
+    ;
+
+    private HttpStatus httpStatus;
+    private String message;
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
@@ -30,15 +30,27 @@ public class MemberService {
 
     private final AwsS3Service awsS3Service;
 
-    public MemberResponseDto saveMember(MemberRegisterDto registerDto) {
+    public MemberResponseDto saveMember(MemberRegisterDto memberRegisterDto) {
+        // 아이디 중복 확인
+        memberRepository.findById(memberRegisterDto.getUserId())
+                .ifPresent(member -> {
+                    throw new RestApiException(ID_ALREADY_EXISTS);
+                });
+
+        // 이메일 중복 확인
+        memberRepository.findByEmail(memberRegisterDto.getEmail())
+                .ifPresent(member -> {
+                    throw new RestApiException(EMAIL_ALREADY_REGISTERED);
+                });
+
         // 비밀번호 암호화
-        String encodedPassword = passwordEncoder.encode(registerDto.getPassword());
+        String encodedPassword = passwordEncoder.encode(memberRegisterDto.getPassword());
 
         // 저장
         Member member = Member.builder()
-                .email(registerDto.getEmail())
-                .userId(registerDto.getUserId())
-                .name(registerDto.getName())
+                .email(memberRegisterDto.getEmail())
+                .userId(memberRegisterDto.getUserId())
+                .name(memberRegisterDto.getName())
                 .password(encodedPassword)
                 .lastHomeAccessTime(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/application/MemberService.java
@@ -81,6 +81,12 @@ public class MemberService {
     public MemberResponseDto changeProfile(Member member, MemberEditDto memberEditDto) {
         // 이메일 변경되었는지 확인 -> 변경되었으면 인증용 메일 보내기
         if (!member.getEmail().equals(memberEditDto.getEmail())) {
+            // 이메일 중복 확인
+            memberRepository.findByEmail(memberEditDto.getEmail())
+                    .ifPresent(m -> {
+                        throw new RestApiException(EMAIL_ALREADY_REGISTERED);
+                    });
+
             member.setEmailVerified(false);
             member.setEmail(memberEditDto.getEmail());
             emailConfirmService.createEmailConfirmationToken(member.getUserId(), member.getEmail());
@@ -89,8 +95,6 @@ public class MemberService {
         // 이름과 소개글 변경
         member.setName(memberEditDto.getName());
         member.setIntroduction(memberEditDto.getIntroduction());
-
-        memberRepository.save(member);
 
         return member.memberToResponseDto();
     }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/post/domain/Post.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/post/domain/Post.java
@@ -1,5 +1,6 @@
 package com.example.InstagramCloneCoding.domain.post.domain;
 
+import com.example.InstagramCloneCoding.domain.comment.domain.Comment;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.post.dto.PostResponseDto;
 import lombok.Getter;
@@ -25,7 +26,7 @@ public class Post {
     @Column(name = "post_id", nullable = false)
     private int postId;
 
-    @Column(name = "content", nullable = true)
+    @Column(name = "content")
     private String content;
 
     @CreatedDate
@@ -38,6 +39,9 @@ public class Post {
 
     @OneToMany(mappedBy = "post", orphanRemoval = true)
     private List<PostImage> postImages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
 
     public Post(Member member, String content) {
         this.member = member;


### PR DESCRIPTION
## 개요
댓글 작성, 삭제 기능 구현

## 작업사항
- comment/{post_id}로 CommentDto와 함께 post mapping을 보내면 댓글을 작성할 수 있음.
- CommentDto의 commentId는 해당 댓글이 댓글인지 대댓글인지 구분하는 역할을 함. 만약 commentId가 null 값이라면 댓글인 것이고, null 값이 아니라면 해당 댓글 아이디와 같은 ref 값을 갖는 대댓글임.
<br/>

- comment/{commet_id}로 delete mapping 요청을 보내면 댓글을 삭제할 수 있음.
- 삭제하기 전에 댓글 작성자인지 확인함.
- 댓글인 경우 (ref_step 값이 0인 경우) 해당 댓글에 속해있는 대댓글들까지 전체 삭제함.
- 대댓글인 경우 해당 댓글만 삭제함.

## 변경로직
- 이메일 변경 시 중복된 이메일인지 확인하도록 함.
- 회원가입 시 디비에 회원정보 저장할 때 다시 한 번 중복 검사를 하도록 함.
