### PR TITLE
Member정보 응답할 dto 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok:1.18.14'
 	testAnnotationProcessor 'org.projectlombok:lombok:1.18.14'
 
+	// JpaQueryFactory
 	implementation 'com.querydsl:querydsl-jpa'
 	implementation 'com.querydsl:querydsl-apt'
 

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/api/FollowApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/api/FollowApiController.java
@@ -32,11 +32,20 @@ public class FollowApiController {
 
     @DeleteMapping("/unfollow")
     public ResponseEntity<String> unfollow(@Parameter(hidden = true) @LoggedInUser Member member,
-                                           @RequestParam String followerId) {
-        followService.unfollow(member, followerId);
+                                           @RequestParam String followingId) {
+        followService.unfollow(member, followingId);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body("unfollow success!");
+    }
+
+    @DeleteMapping("/delete/follower")
+    public ResponseEntity<String> deleteFollower(@Parameter(hidden = true) @LoggedInUser Member member,
+                                                 @RequestParam String followerId) {
+        followService.deleteFollow(followerId, member);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body("delete follower success!");
     }
 
     @GetMapping("/getfollowers/{member_id}")

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowFindService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowFindService.java
@@ -3,6 +3,7 @@ package com.example.InstagramCloneCoding.domain.follow.application;
 import com.example.InstagramCloneCoding.domain.follow.dao.FollowRepository;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.member.dto.MemberResponseDto;
+import com.example.InstagramCloneCoding.domain.member.mapper.MemberMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,12 +17,13 @@ import java.util.stream.Collectors;
 public class FollowFindService {
 
     private final FollowRepository followRepository;
+    private final MemberMapper memberMapper;
 
     public List<MemberResponseDto> getFollowers(String memberId) {
         List<Member> followers = followRepository.findFollowersById(memberId);
 
         return followers.stream()
-                .map(Member::memberToResponseDto)
+                .map(memberMapper::toMemberResponseDto)
                 .collect(Collectors.toList());
     }
 
@@ -29,7 +31,7 @@ public class FollowFindService {
         List<Member> followings = followRepository.findFollowingsById(memberId);
 
         return followings.stream()
-                .map(Member::memberToResponseDto)
+                .map(memberMapper::toMemberResponseDto)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import static com.example.InstagramCloneCoding.domain.follow.error.FollowError.ALREADY_FOLLOWING;
 import static com.example.InstagramCloneCoding.domain.follow.error.FollowError.NOT_FOLLOWING;
 import static com.example.InstagramCloneCoding.domain.member.error.MemberErrorCode.MEMBER_NOT_FOUND;
+import static com.example.InstagramCloneCoding.global.error.CommonErrorCode.FORBIDDEN;
 
 @Service
 @Transactional(readOnly = true)
@@ -25,6 +26,11 @@ public class FollowService {
     public void follow(Member follower, String followingId) {
         Member following = memberRepository.findById(followingId)
                 .orElseThrow(() -> new RestApiException(MEMBER_NOT_FOUND));
+
+        // 본인 팔로우 불가능
+        if(follower==following){
+            throw new RestApiException(FORBIDDEN);
+        }
 
         // follow 중복 검사
         followRepository.findByFollowerAndFollowing(follower, following)

--- a/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/follow/application/FollowService.java
@@ -15,20 +15,19 @@ import static com.example.InstagramCloneCoding.domain.member.error.MemberErrorCo
 import static com.example.InstagramCloneCoding.global.error.CommonErrorCode.FORBIDDEN;
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @RequiredArgsConstructor
 public class FollowService {
 
     private final FollowRepository followRepository;
     private final MemberRepository memberRepository;
 
-    @Transactional
     public void follow(Member follower, String followingId) {
         Member following = memberRepository.findById(followingId)
                 .orElseThrow(() -> new RestApiException(MEMBER_NOT_FOUND));
 
         // 본인 팔로우 불가능
-        if(follower==following){
+        if (follower == following) {
             throw new RestApiException(FORBIDDEN);
         }
 
@@ -41,16 +40,23 @@ public class FollowService {
         followRepository.save(new Follow(follower, following));
     }
 
-    @Transactional
     public void unfollow(Member follower, String followingId) {
         Member following = memberRepository.findById(followingId)
                 .orElseThrow(() -> new RestApiException(MEMBER_NOT_FOUND));
 
-        Follow follow = followRepository.findByFollowerAndFollowing(follower, following).orElse(null);
         // follow 확인
-        if (follow == null) {
-            throw new RestApiException(NOT_FOLLOWING);
-        }
+        Follow follow = followRepository.findByFollowerAndFollowing(follower, following)
+                .orElseThrow(() -> new RestApiException(NOT_FOLLOWING));
+
+        followRepository.delete(follow);
+    }
+
+    public void deleteFollow(String followerId, Member following) {
+        Member follower = memberRepository.findById(followerId)
+                .orElseThrow(() -> new RestApiException(MEMBER_NOT_FOUND));
+
+        Follow follow = followRepository.findByFollowerAndFollowing(follower, following)
+                .orElseThrow(() -> new RestApiException(NOT_FOLLOWING));
 
         followRepository.delete(follow);
     }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberAccountsApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberAccountsApiController.java
@@ -1,8 +1,12 @@
 package com.example.InstagramCloneCoding.domain.member.api;
 
 import com.example.InstagramCloneCoding.domain.member.application.MemberService;
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.member.dto.MemberRegisterDto;
 import com.example.InstagramCloneCoding.domain.member.dto.MemberResponseDto;
+import com.example.InstagramCloneCoding.domain.member.dto.ProfileResponseDto;
+import com.example.InstagramCloneCoding.global.common.annotation.LoggedInUser;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -31,5 +35,14 @@ public class MemberAccountsApiController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(memberResponseDto);
+    }
+
+    @GetMapping("{member_id}")
+    public ResponseEntity<ProfileResponseDto> profile(@Parameter(hidden = true) @LoggedInUser Member member,
+                                                      @PathVariable(name = "member_id") String targetId) {
+        ProfileResponseDto profileResponseDto = memberService.findAccount(member, targetId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(profileResponseDto);
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberEditApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberEditApiController.java
@@ -4,7 +4,7 @@ import com.example.InstagramCloneCoding.domain.member.application.EmailConfirmSe
 import com.example.InstagramCloneCoding.domain.member.application.MemberService;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.member.dto.MemberEditDto;
-import com.example.InstagramCloneCoding.domain.member.dto.MemberResponseDto;
+import com.example.InstagramCloneCoding.domain.member.dto.ProfileResponseDto;
 import com.example.InstagramCloneCoding.global.common.annotation.LoggedInUser;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
@@ -26,23 +26,23 @@ public class MemberEditApiController {
     private final EmailConfirmService emailConfirmService;
 
     @PostMapping(value = "profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<MemberResponseDto> changeProfileImage(@Parameter(hidden = true) @LoggedInUser Member member,
-                                                                @RequestPart("image") List<MultipartFile> multipartFile) {
+    public ResponseEntity<String> changeProfileImage(@Parameter(hidden = true) @LoggedInUser Member member,
+                                                     @RequestPart("image") List<MultipartFile> multipartFile) {
 
-        MemberResponseDto memberResponseDto = memberService.changeProfileImage(member, multipartFile);
+        String imagePath = memberService.changeProfileImage(member, multipartFile);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(memberResponseDto);
+                .body(imagePath);
     }
 
     @PostMapping("profile")
-    public ResponseEntity<MemberResponseDto> changeProfile(@Parameter(hidden = true) @LoggedInUser Member member,
-                                                           @RequestBody MemberEditDto memberEditDto) {
+    public ResponseEntity<ProfileResponseDto> changeProfile(@Parameter(hidden = true) @LoggedInUser Member member,
+                                                            @RequestBody MemberEditDto memberEditDto) {
 
-        MemberResponseDto memberResponseDto = memberService.changeProfile(member, memberEditDto);
+        ProfileResponseDto profileResponseDto = memberService.changeProfile(member, memberEditDto);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(memberResponseDto);
+                .body(profileResponseDto);
     }
 
     @GetMapping("confirm-email")

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/domain/Member.java
@@ -67,8 +67,4 @@ public class Member {
         this.emailVerified = true;
         this.lastHomeAccessTime = lastHomeAccessTime;
     }
-
-    public MemberResponseDto memberToResponseDto(){
-        return new MemberResponseDto(userId, email, name, profileImage, introduction);
-    }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/dto/MemberResponseDto.java
@@ -11,11 +11,7 @@ public class MemberResponseDto {
 
     private String userId;
 
-    private String email;
-
     private String name;
 
     private String profileImage;
-
-    private String introduction;
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/dto/ProfileResponseDto.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/dto/ProfileResponseDto.java
@@ -1,0 +1,38 @@
+package com.example.InstagramCloneCoding.domain.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ProfileResponseDto {
+    private String userId;
+
+    private String name;
+
+    private String profileImage;
+
+    private String introduction;
+
+    private int followerCount;
+
+    private int followingCount;
+
+    private boolean iFollowed;
+
+    private boolean isMe;
+
+    @Builder
+    public ProfileResponseDto(String userId, String name, String profileImage, String introduction,
+                              int followerCount, int followingCount, boolean iFollowed, boolean isMe) {
+        this.userId = userId;
+        this.name = name;
+        this.profileImage = profileImage;
+        this.introduction = introduction;
+        this.followerCount = followerCount;
+        this.followingCount = followingCount;
+        this.iFollowed = iFollowed;
+        this.isMe = isMe;
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/mapper/MemberMapper.java
@@ -1,0 +1,35 @@
+package com.example.InstagramCloneCoding.domain.member.mapper;
+
+import com.example.InstagramCloneCoding.domain.follow.dao.FollowRepository;
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
+import com.example.InstagramCloneCoding.domain.member.dto.MemberResponseDto;
+import com.example.InstagramCloneCoding.domain.member.dto.ProfileResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberMapper {
+
+    private final FollowRepository followRepository;
+
+    public MemberResponseDto toMemberResponseDto(Member entity) {
+        return new MemberResponseDto(entity.getUserId(), entity.getName(), entity.getProfileImage());
+    }
+
+    public ProfileResponseDto toProfileResponse(Member entity, Member member) {
+        boolean isMe = entity.equals(member);
+        boolean iFollowed = followRepository.findByFollowerAndFollowing(member, entity).isPresent();
+
+        return ProfileResponseDto.builder()
+                .userId(entity.getUserId())
+                .name(entity.getName())
+                .profileImage(entity.getProfileImage())
+                .introduction(entity.getIntroduction())
+                .followerCount(entity.getFollowers().size())
+                .followingCount(entity.getFollowings().size())
+                .iFollowed(iFollowed)
+                .isMe(isMe)
+                .build();
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/InstagramCloneCoding/global/config/SecurityConfig.java
@@ -44,7 +44,8 @@ public class SecurityConfig {
         http.authorizeRequests()
                 .antMatchers("/auth/signin").permitAll() // 모든 요청 허가
                 .antMatchers("/auth/reissue").permitAll()
-                .antMatchers("/accounts/**").permitAll()
+                .antMatchers("/accounts/check").permitAll()
+                .antMatchers("/accounts/save").permitAll()
                 .antMatchers(SWAGGER_LIST).permitAll()
                 .anyRequest().authenticated()   // 나머지 인증 필요
                 .and()


### PR DESCRIPTION
## 개요
- Member 정보 리턴 구현
- Follower 삭제 기능 추가 구현

## 작업사항
- ProfileResponseDto : 아이디, 이름, 프로필 사진, 설명, 팔로우 수, 팔로워 수, 내가 팔로우하는지 여부, 본인 여부 의 정보를 가지고 리턴하게 함
- MemberResponseDto : 아이디, 이름, 프로필 사진으로 간단한 정보만 리턴하게 함
<br>

- 인스타그램에 나를 팔로우하고 있는 팔로워 삭제도 가능하길래 그 기능도 추가로 구현함 

## 변경로직
- /edit/profile-image 의 리턴값을 기존 MemberResponseDto 에서 이미지 경로인 String으로 변경했다. 인스타그램에서 사진이 즉각적으로 변했기 때문
- 생성한 MemberMapper로 Member관련 dto 매핑하도록 변경
- 팔로우 시 본인 팔로우 불가능하게 구현
