### PR TITLE
회원 계정 삭제 구현

### DIFF
--- a/src/main/java/com/example/InstagramCloneCoding/domain/comment/dao/CommentRepository.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/comment/dao/CommentRepository.java
@@ -2,6 +2,7 @@ package com.example.InstagramCloneCoding.domain.comment.dao;
 
 import com.example.InstagramCloneCoding.domain.comment.domain.Comment;
 import com.example.InstagramCloneCoding.domain.feed.domain.Post;
+import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,4 +14,6 @@ public interface CommentRepository extends JpaRepository<Comment, Integer> {
     List<Comment> findByPostAndRef(Post post, int ref);
 
     List<Comment> findByRef(int ref);
+
+    List<Comment> findByMember(Member member);
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/feed/dao/PostRepository.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/feed/dao/PostRepository.java
@@ -12,4 +12,6 @@ import java.util.List;
 public interface PostRepository extends JpaRepository<Post, Integer> {
 
     List<Post> findByAuthorInAndCreatedAtGreaterThanEqual(List<Member> authors, LocalDateTime accessTime);
+
+    List<Post> findByAuthor(Member author);
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberAccountsApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberAccountsApiController.java
@@ -12,6 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("accounts/")
 @RequiredArgsConstructor
@@ -44,5 +46,14 @@ public class MemberAccountsApiController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(profileResponseDto);
+    }
+
+    @DeleteMapping("delete")
+    public ResponseEntity<String> delete(@Parameter(hidden = true) @LoggedInUser Member member,
+                                         @RequestBody Map<String, String> passwordMap) {
+        memberService.deleteAccount(member, passwordMap.get("password"));
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body("delete account success!");
     }
 }


### PR DESCRIPTION
## 개요
계정 삭제 구현

## 작업사항
- accounts/delete로 delete mapping 요청을 보내면 회원 계정이 삭제됨. 이때 비밀번호를 같이 보내야 됨.
- 비밀번호가 맞으면 회원 삭제를 진행함.
- 우선 s3 버킷에서 프로필 이미지와 해당 회원이 작성한 포스트의 이미지들을 삭제함.
- 그런 후에 댓글을 삭제하는데, 댓글을 그냥 놔두기로 했던 것 같아서 일단 주석 처리 해놓음.
- 마지막으로 회원 정보를 디비에서 삭제함.