### PR TITLE
댓글 읽어오기 구현

### DIFF
--- a/src/main/java/com/example/InstagramCloneCoding/domain/comment/api/CommentController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/comment/api/CommentController.java
@@ -11,6 +11,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("comment/")
 @RequiredArgsConstructor
@@ -29,10 +31,19 @@ public class CommentController {
     }
 
     @DeleteMapping("{comment_id}")
-    public ResponseEntity delete(@Parameter(hidden = true) @LoggedInUser Member member,
+    public ResponseEntity<String> delete(@Parameter(hidden = true) @LoggedInUser Member member,
                                  @PathVariable("comment_id") int commentId) {
         commentService.deleteComment(member, commentId);
 
-        return ResponseEntity.status(HttpStatus.OK).build();
+        return ResponseEntity.status(HttpStatus.OK)
+                .body("delete comment success");
+    }
+
+    @GetMapping("{post_id}")
+    public ResponseEntity<List<CommentResponseDto>> readAll(@PathVariable("post_id") int postId) {
+        List<CommentResponseDto> commentResponseDtos = commentService.readAllComments(postId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(commentResponseDtos);
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/comment/application/CommentService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/comment/application/CommentService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import javax.transaction.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.example.InstagramCloneCoding.domain.comment.error.CommentErrorCode.COMMENT_NOT_FOUND;
 import static com.example.InstagramCloneCoding.domain.comment.error.CommentErrorCode.UNAVAILABLE_COMMENT_REQUEST;
@@ -92,5 +93,16 @@ CommentService {
         else {
             commentRepository.delete(deleteComment);
         }
+    }
+
+    public List<CommentResponseDto> readAllComments(int postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new RestApiException(POST_NOT_FOUND));
+
+        List<Comment> comments = commentRepository.findByPostOrderByRefAscRefStepAsc(post);
+
+        return comments.stream()
+                .map(commentMapper::toDto)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/comment/application/CommentService.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/comment/application/CommentService.java
@@ -4,6 +4,7 @@ import com.example.InstagramCloneCoding.domain.comment.dao.CommentRepository;
 import com.example.InstagramCloneCoding.domain.comment.domain.Comment;
 import com.example.InstagramCloneCoding.domain.comment.dto.CommentDto;
 import com.example.InstagramCloneCoding.domain.comment.dto.CommentResponseDto;
+import com.example.InstagramCloneCoding.domain.comment.mapper.CommentMapper;
 import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import com.example.InstagramCloneCoding.domain.feed.dao.PostRepository;
 import com.example.InstagramCloneCoding.domain.feed.domain.Post;
@@ -29,6 +30,8 @@ CommentService {
     private final PostRepository postRepository;
 
     private final CommentRepository commentRepository;
+
+    private final CommentMapper commentMapper;
 
     public CommentResponseDto writeComment(Member member, int postId, CommentDto commentDto) {
         int ref, refStep;
@@ -69,7 +72,7 @@ CommentService {
                 .build();
         commentRepository.save(comment);
 
-        return comment.commentToResponseDto();
+        return commentMapper.toDto(comment);
     }
 
     public void deleteComment(Member member, int commentId) {

--- a/src/main/java/com/example/InstagramCloneCoding/domain/comment/dao/CommentRepository.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/comment/dao/CommentRepository.java
@@ -13,4 +13,6 @@ public interface CommentRepository extends JpaRepository<Comment, Integer> {
     List<Comment> findByPostAndRef(Post post, int ref);
 
     List<Comment> findByRef(int ref);
+
+    List<Comment> findByPostOrderByRefAscRefStepAsc(Post post);
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/comment/domain/Comment.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/comment/domain/Comment.java
@@ -54,8 +54,4 @@ public class Comment {
         this.ref = ref;
         this.refStep = refStep;
     }
-
-    public CommentResponseDto commentToResponseDto() {
-        return new CommentResponseDto(commentId, post.getPostId(), member.getUserId(), content, createdAt, ref);
-    }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/comment/dto/CommentResponseDto.java
@@ -14,7 +14,9 @@ public class CommentResponseDto {
 
     private int postId;
 
-    private String userId;
+    private String authorId;
+
+    private String authorProfileImage;
 
     private String content;
 
@@ -24,12 +26,14 @@ public class CommentResponseDto {
     int ref;
 
     @Builder
-    public CommentResponseDto(int commentId, int postId, String userId, String content, LocalDateTime createdAt, int ref) {
+    public CommentResponseDto(int commentId, int postId, String authorId, String content, LocalDateTime createdAt,
+                              int ref, String authorProfileImage) {
         this.commentId = commentId;
         this.postId = postId;
-        this.userId = userId;
+        this.authorId = authorId;
         this.content = content;
         this.createdAt = createdAt;
         this.ref = ref;
+        this.authorProfileImage = authorProfileImage;
     }
 }

--- a/src/main/java/com/example/InstagramCloneCoding/domain/comment/mapper/CommentMapper.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/comment/mapper/CommentMapper.java
@@ -1,0 +1,23 @@
+package com.example.InstagramCloneCoding.domain.comment.mapper;
+
+import com.example.InstagramCloneCoding.domain.comment.domain.Comment;
+import com.example.InstagramCloneCoding.domain.comment.dto.CommentResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommentMapper {
+
+    public CommentResponseDto toDto(Comment comment) {
+        return CommentResponseDto.builder()
+                .commentId(comment.getCommentId())
+                .postId(comment.getPost().getPostId())
+                .authorId(comment.getMember().getUserId())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .ref(comment.getRef())
+                .authorProfileImage(comment.getMember().getProfileImage())
+                .build();
+    }
+}

--- a/src/main/java/com/example/InstagramCloneCoding/domain/feed/dto/PostResponseDto.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/feed/dto/PostResponseDto.java
@@ -31,9 +31,11 @@ public class PostResponseDto {
 
     private boolean iLiked;
 
+    private int commentCount;
+
     @Builder
     public PostResponseDto(int postId, String authorId, String content, LocalDateTime createdAt,
-                           List<PostImage> postImages, int likes, boolean iLiked, String authorProfileImage) {
+                           List<PostImage> postImages, int likes, boolean iLiked, String authorProfileImage, int commentCount) {
         this.postId = postId;
         this.authorId = authorId;
         this.content = content;
@@ -42,6 +44,7 @@ public class PostResponseDto {
         this.likes = likes;
         this.iLiked = iLiked;
         this.authorProfileImage = authorProfileImage;
+        this.commentCount = commentCount;
     }
 
     private List<String> getPostImagesName(List<PostImage> postImages) {

--- a/src/main/java/com/example/InstagramCloneCoding/domain/feed/mapper/PostMapper.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/feed/mapper/PostMapper.java
@@ -25,6 +25,7 @@ public class PostMapper {
                 .likes(post.getLikes().size())
                 .iLiked(iLiked)
                 .authorProfileImage(member.getProfileImage())
+                .commentCount(post.getComments().size())
                 .build();
     }
 }


### PR DESCRIPTION
## 개요
댓글 읽어오기 구현

## 작업사항
- comment/{postId}로 get 요청을 보내면 List<CommentResponseDto> 형태로 응답 반환.
- CommentResponseDto에는 ref만 있고 ref_step은 없는데, 이미 정렬된 상태로 반환해주기 때문. ref끼리 묶어서 차례대로 화면에 뿌려주면 된다.

## 변경로직
- PostResponseDto에 commentCount 추가
- Comment 클래스의 commentToResponseDto() 메소드를 CommentMapper로 변경
- CommentResponseDto에 userId를 authorId로 바꾸고 authorProfileImage 추가
