### PR TITLE
feat: "검색창에서 아이디, 이름으로 검색 시 해당 멤버 목록 조회 기능 구현"

### DIFF
--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberAccountsApiController.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/api/MemberAccountsApiController.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -46,6 +47,15 @@ public class MemberAccountsApiController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(profileResponseDto);
+    }
+
+    @GetMapping("search/{member_id}")
+    public ResponseEntity<List<MemberResponseDto>> search(@Parameter(hidden = true) @LoggedInUser Member member,
+                                                          @PathVariable(name = "member_id") String targetId) {
+        List<MemberResponseDto> members = memberService.search(targetId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(members);
     }
 
     @DeleteMapping("delete")

--- a/src/main/java/com/example/InstagramCloneCoding/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/example/InstagramCloneCoding/domain/member/dao/MemberRepository.java
@@ -4,6 +4,7 @@ import com.example.InstagramCloneCoding.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -12,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, String> {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByUserIdOrEmail(String id, String email);
+
+    List<Member> findByUserIdOrName(String id, String name);
 }


### PR DESCRIPTION
## 개요
- 멤버를 이름 혹은 아이디로 검색하는 기능 구현

## 작업사항
- MemberRepository에 findByUserIdOrName 추가하여 해당 메소드로 DB 탐색
- "accounts/search/{member_id}"로 검색된 member들은 아이디, 이름, 이미지를 담아 리스트로 조회된다.
